### PR TITLE
Write DisplayVersion, Publisher and DisplayIcon to ARP entry

### DIFF
--- a/package/NSIS/Installer.nsi
+++ b/package/NSIS/Installer.nsi
@@ -77,6 +77,7 @@ Section
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "DLSS Swapper"
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "1.0.2.0"
   WriteRegStr SHCTX "${UNINST_KEY}" "Publisher" "beeradmoore"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayIcon" "$\"$INSTDIR\DLSS Swapper.exe$\""
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
   WriteRegStr SHCTX "${UNINST_KEY}" "InstallLocation" $INSTDIR
 

--- a/package/NSIS/Installer.nsi
+++ b/package/NSIS/Installer.nsi
@@ -75,6 +75,8 @@ Section
   CreateShortcut "$SMPROGRAMS\DLSS Swapper.lnk" "$INSTDIR\DLSS Swapper.exe"
 
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "DLSS Swapper"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "1.0.2.0"
+  WriteRegStr SHCTX "${UNINST_KEY}" "Publisher" "beeradmoore"
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""
   WriteRegStr SHCTX "${UNINST_KEY}" "InstallLocation" $INSTDIR
 


### PR DESCRIPTION
This PR fills these two empty fields and replace the default icon with the program's for the future installers. You can choose another name for the Publisher field.

Before:

![image](https://github.com/beeradmoore/dlss-swapper/assets/56779163/4a4716bf-6481-4de0-827c-06087bfdb284)

After:

![image](https://github.com/beeradmoore/dlss-swapper/assets/56779163/dae552c6-77f4-437c-ad46-4a99f38af54a)