### PR TITLE
Fix app crash when no internet connection is available

### DIFF
--- a/src/Data/DLSSRecord.cs
+++ b/src/Data/DLSSRecord.cs
@@ -156,15 +156,30 @@ namespace DLSS_Swapper.Data
 
             _cancellationTokenSource?.Cancel();
 
-            LocalRecord.IsDownloading = true;
-            LocalRecord.DownloadProgress = 0;
-            LocalRecord.HasDownloadError = false;
-            LocalRecord.DownloadErrorMessage = String.Empty;
-            NotifyPropertyChanged("LocalRecord");
-
             _cancellationTokenSource = new CancellationTokenSource();
             var cancellationToken = _cancellationTokenSource.Token;
-            var response = await App.CurrentApp.HttpClient.GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+
+            HttpResponseMessage response;
+            try
+            {
+                response = await App.CurrentApp.HttpClient.GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
+
+            LocalRecord.IsDownloading = true;
+            LocalRecord.DownloadProgress = 0;
+                NotifyPropertyChanged("LocalRecord");
+            }
+            catch (HttpRequestException ex)
+            {
+                Logger.Error(ex.Message);
+
+                LocalRecord.IsDownloading = false;
+                LocalRecord.HasDownloadError = true;
+                LocalRecord.DownloadErrorMessage = "Could not download DLSS. Please check your internet connection!";
+            NotifyPropertyChanged("LocalRecord");
+
+                return (false, "Could not download DLSS. Please check your internet connection!", false);
+            }
+            
             if (response.StatusCode != System.Net.HttpStatusCode.OK)
             {
 

--- a/src/Data/DLSSRecord.cs
+++ b/src/Data/DLSSRecord.cs
@@ -149,7 +149,7 @@ namespace DLSS_Swapper.Data
         {
             var dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-            if (string.IsNullOrWhiteSpace(DownloadUrl))
+            if (string.IsNullOrEmpty(DownloadUrl))
             {
                 return (false, "Invalid download URL.", false);
             }

--- a/src/Data/DLSSRecord.cs
+++ b/src/Data/DLSSRecord.cs
@@ -149,7 +149,7 @@ namespace DLSS_Swapper.Data
         {
             var dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
 
-            if (String.IsNullOrEmpty(DownloadUrl))
+            if (string.IsNullOrWhiteSpace(DownloadUrl))
             {
                 return (false, "Invalid download URL.", false);
             }
@@ -164,8 +164,8 @@ namespace DLSS_Swapper.Data
             {
                 response = await App.CurrentApp.HttpClient.GetAsync(DownloadUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken);
 
-            LocalRecord.IsDownloading = true;
-            LocalRecord.DownloadProgress = 0;
+                LocalRecord.IsDownloading = true;
+                LocalRecord.DownloadProgress = 0;
                 NotifyPropertyChanged("LocalRecord");
             }
             catch (HttpRequestException ex)
@@ -175,14 +175,13 @@ namespace DLSS_Swapper.Data
                 LocalRecord.IsDownloading = false;
                 LocalRecord.HasDownloadError = true;
                 LocalRecord.DownloadErrorMessage = "Could not download DLSS. Please check your internet connection!";
-            NotifyPropertyChanged("LocalRecord");
+                NotifyPropertyChanged("LocalRecord");
 
                 return (false, "Could not download DLSS. Please check your internet connection!", false);
             }
             
             if (response.StatusCode != System.Net.HttpStatusCode.OK)
             {
-
                 dispatcherQueue.TryEnqueue(() =>
                 {
                     LocalRecord.IsDownloading = false;
@@ -199,8 +198,6 @@ namespace DLSS_Swapper.Data
             var totalBytesRead = 0L;
             var buffer = new byte[1024 * 8];
             var isMoreToRead = true;
-
-
 
             var guid = Guid.NewGuid().ToString().ToUpper();
 
@@ -262,10 +259,7 @@ namespace DLSS_Swapper.Data
                     NotifyPropertyChanged("LocalRecord");
                 });
 
-                
-
                 File.Move(tempZipFile, Path.Combine(targetZipDirectory, $"{Version}_{MD5Hash}.zip"), true);
-
 
                 dispatcherQueue.TryEnqueue(() =>
                 {
@@ -286,7 +280,6 @@ namespace DLSS_Swapper.Data
                     LocalRecord.IsDownloaded = false;
                     NotifyPropertyChanged("LocalRecord");
                 });
-
 
                 return (false, String.Empty, true);
             }

--- a/src/Data/DLSSRecord.cs
+++ b/src/Data/DLSSRecord.cs
@@ -180,7 +180,7 @@ namespace DLSS_Swapper.Data
                 return (false, "Could not download DLSS. Please check your internet connection!", false);
             }
             
-            if (response.StatusCode != System.Net.HttpStatusCode.OK)
+            if (response.StatusCode is not System.Net.HttpStatusCode.OK)
             {
                 dispatcherQueue.TryEnqueue(() =>
                 {
@@ -218,7 +218,7 @@ namespace DLSS_Swapper.Data
                         {
                             var bytesRead = await contentStream.ReadAsync(buffer, 0, buffer.Length, cancellationToken).ConfigureAwait(false);
 
-                            if (bytesRead == 0)
+                            if (bytesRead is 0)
                             {
                                 isMoreToRead = false;
                                 continue;
@@ -227,7 +227,6 @@ namespace DLSS_Swapper.Data
                             await fileStream.WriteAsync(buffer, 0, bytesRead, cancellationToken).ConfigureAwait(false);
 
                             totalBytesRead += bytesRead;
-
 
                             if ((DateTimeOffset.Now - lastUpdated).TotalMilliseconds > 100)
                             {

--- a/src/Data/DLSSRecord.cs
+++ b/src/Data/DLSSRecord.cs
@@ -1,17 +1,12 @@
-﻿using DLSS_Swapper.Extensions;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.IO;
-using System.IO.Compression;
-using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using DLSS_Swapper.Extensions;
 
 namespace DLSS_Swapper.Data
 {
@@ -114,7 +109,6 @@ namespace DLSS_Swapper.Data
             }
         }
 
-
         [JsonIgnore]
         public LocalRecord LocalRecord { get; set; }
 
@@ -128,13 +122,14 @@ namespace DLSS_Swapper.Data
             return other.VersionNumber.CompareTo(VersionNumber);
         }
 
-
         #region INotifyPropertyChanged
+
         public event PropertyChangedEventHandler PropertyChanged;
         internal void NotifyPropertyChanged([CallerMemberName] String propertyName = "")
         {
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
         }
+        
         #endregion
 
         private CancellationTokenSource _cancellationTokenSource;

--- a/src/Pages/LibraryPage.xaml.cs
+++ b/src/Pages/LibraryPage.xaml.cs
@@ -657,7 +657,7 @@ Only import dlls from sources you trust.",
         async Task DownloadRecordAsync(DLSSRecord record)
         {
             var result = await record?.DownloadAsync();
-            if (result.Success == false && result.Cancelled == false)
+            if (result.Success is false && result.Cancelled is false)
             {
                 var dialog = new EasyContentDialog(XamlRoot)
                 {
@@ -666,6 +666,7 @@ Only import dlls from sources you trust.",
                     DefaultButton = ContentDialogButton.Close,
                     Content = result.Message,
                 };
+
                 await dialog.ShowAsync();
             }
         }


### PR DESCRIPTION
### Summary
This resolves #92.

### Detailed Changes
Added a try catch around the `HttpRequestMessage`.
If an `HttpRequestException` occurs it will return and display an error message to the user about checking the internet connection.

I also had to remove the `ConfigureAwait(false)` addition at the `HttpClient#GetAsync` statement because it would've crashed the app again when the connection is back (Don't ask me why but the bug was gone after I removed it!).

### Notes
I also made small formatting changes to the methods (nothing breaking tho, this PR is only intended to fix the issue).