### PR TITLE
Added cover loading when GOG Galaxy is not installed

### DIFF
--- a/src/Data/GOG/GOGCatalogResponse.cs
+++ b/src/Data/GOG/GOGCatalogResponse.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace DLSS_Swapper.Data.GOG;
+
+/// <summary>
+/// This class is the json repsonse from https://catalog.gog.com/v1/catalog?order=desc:score&productType=in:game&query=like:gameTitleGoesHere
+/// </summary>
+class GOGCatalogResponse
+{
+    [JsonPropertyName("products")]
+    public GOGCatalogProduct[] Products { get; set; } = Array.Empty<GOGCatalogProduct>();
+
+    [JsonPropertyName("pages")]
+    public int Pages { get; set; }
+
+    [JsonPropertyName("productCount")]
+    public int ProductCount { get; set; }
+
+    [JsonPropertyName("currentlyShownProductCount")]
+    public int CurrentlyShownProductCount { get; set; }
+}
+
+class GOGCatalogProduct
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("coverHorizontal")]
+    public string CoverHorizontal { get; set; } = string.Empty;
+
+    [JsonPropertyName("coverVertical")]
+    public string CoverVertical { get; set; } = string.Empty;
+}

--- a/src/Data/GOG/GOGEmbedFilteredResponse.cs
+++ b/src/Data/GOG/GOGEmbedFilteredResponse.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace DLSS_Swapper.Data.GOG;
+
+/// <summary>
+/// This class is the json repsonse from https://embed.gog.com/games/ajax/filtered?mediaType=game&search=gameTitleGoesHere
+/// </summary>
+class GOGEmbedFilteredResponse
+{
+    [JsonPropertyName("products")]
+    public GOGEmbedFilteredProduct[] Products { get; set; } = Array.Empty<GOGEmbedFilteredProduct>();
+
+    [JsonPropertyName("page")]
+    public int Page { get; set; }
+
+    [JsonPropertyName("totalPages")]
+    public int TotalPages { get; set; }
+
+    [JsonPropertyName("totalResults")]
+    public string TotalResults { get; set; } = string.Empty;
+
+    [JsonPropertyName("totalGamesFound")]
+    public int TotalGamesFound { get; set; }
+}
+
+class GOGEmbedFilteredProduct
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("image")]
+    public string Image { get; set; } = string.Empty;
+
+    [JsonPropertyName("boxImage")]
+    public string BoxImage { get; set; } = string.Empty;
+}

--- a/src/Data/GOG/GOGGame.cs
+++ b/src/Data/GOG/GOGGame.cs
@@ -1,7 +1,15 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
+using DLSS_Swapper.Helpers;
 using DLSS_Swapper.Interfaces;
+using Microsoft.UI.Xaml;
 
 namespace DLSS_Swapper.Data.GOG
 {
@@ -39,7 +47,143 @@ namespace DLSS_Swapper.Data.GOG
                 }
             }
 
-            await DownloadCoverAsync(FallbackHeaderUrl).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(FallbackHeaderUrl) == false)
+            {
+                await DownloadCoverAsync(FallbackHeaderUrl).ConfigureAwait(false);
+                return;
+            }
+
+
+            // If we don't have a cover to download we can try get it from various search APIs.
+            // Some games are not found here (eg. Warecraft III) and instead will fallback
+            // to using the direct product loading below. Unfortuantly using the product
+            // endpoint does not contain boxart image urls so the images are not really
+            // what we want, but at least there is images.
+
+
+            try
+            {
+                var url = "https://catalog.gog.com/v1/catalog?order=desc:score&productType=in:game&query=like:" + Uri.EscapeDataString(Title);
+                var fileDownloader = new FileDownloader(url);
+                using (var memoryStream = new MemoryStream())
+                {
+                    await fileDownloader.DownloadFileToStreamAsync(memoryStream);
+                    memoryStream.Position = 0;
+
+                    var catalogResponse = JsonSerializer.Deserialize<GOGCatalogResponse>(memoryStream);
+                    if (catalogResponse is null)
+                    {
+                        throw new Exception($"Could not deserialize GOGCatalogResponse for url, {url}");
+                    }
+
+                    if (catalogResponse.Products.Length == 0)
+                    {
+                        throw new Exception($"Could not find any GOGCatalogProduct for url, {url}");
+                    }
+
+                    foreach (var product in catalogResponse.Products)
+                    {
+                        if (product.Id.ToString().Equals(PlatformId, StringComparison.OrdinalIgnoreCase) == false)
+                        {
+                            continue;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(product.CoverVertical) == false)
+                        {
+                            await DownloadCoverAsync(product.CoverVertical).ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (Exception err)
+            {
+                Logger.Error(err);
+                //Debugger.Break();
+            }
+
+
+            // If catalog failed fall back to embeded search.
+            try
+            {
+                var url = "https://embed.gog.com/games/ajax/filtered?mediaType=game&search=" + Uri.EscapeDataString(Title);
+                var fileDownloader = new FileDownloader(url);
+                using (var memoryStream = new MemoryStream())
+                {
+                    await fileDownloader.DownloadFileToStreamAsync(memoryStream);
+                    memoryStream.Position = 0;
+
+                    var embedFilteredResponse = JsonSerializer.Deserialize<GOGEmbedFilteredResponse>(memoryStream);
+                    if (embedFilteredResponse is null)
+                    {
+                        throw new Exception($"Could not deserialize GOGEmbedFilteredResponse for url, {url}");
+                    }
+
+                    if (embedFilteredResponse.Products.Length == 0)
+                    {
+                        throw new Exception($"Could not find any GOGEmbedFilteredProducts for url, {url}");
+                    }
+
+                    foreach (var product in embedFilteredResponse.Products)
+                    {
+                        if (product.Id.ToString().Equals(PlatformId, StringComparison.OrdinalIgnoreCase) == false)
+                        {
+                            continue;
+                        }
+
+                        if (string.IsNullOrWhiteSpace(product.BoxImage) == false)
+                        {
+                            await DownloadCoverAsync($"https:{product.BoxImage}_glx_vertical_cover.webp").ConfigureAwait(false);
+                            return;
+                        }
+                        else if (string.IsNullOrWhiteSpace(product.Image) == false)
+                        {
+                            await DownloadCoverAsync($"https:{product.Image}_glx_vertical_cover.webp").ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                }
+
+            }
+            catch (Exception err)
+            {
+                Logger.Error(err);
+                //Debugger.Break();
+            }
+                        
+
+            // If we got here then we did not find the game in search. We can load from the product endpoint
+            // But doing this the cover image is likely not what we want.
+            try
+            {
+                var url = "https://api.gog.com/products/" + PlatformId;
+                var fileDownloader = new FileDownloader(url);
+
+                using (var memoryStream = new MemoryStream())
+                {
+                    await fileDownloader.DownloadFileToStreamAsync(memoryStream);
+
+                    memoryStream.Position = 0;
+
+                    var gogProduct = JsonSerializer.Deserialize<GOGProduct>(memoryStream);
+
+                    if (gogProduct?.Images is not null)
+                    {
+                        if (string.IsNullOrWhiteSpace(gogProduct.Images.Logo) == false)
+                        {
+                            var newCoverUrl = $"https:{gogProduct.Images.Logo.Replace("glx_logo", "glx_vertical_cover")}";
+                            await DownloadCoverAsync(newCoverUrl).ConfigureAwait(false);
+                            return;
+                        }
+                    }
+                }
+            }
+            catch (Exception err)
+            {
+                Logger.Error(err);
+                Debugger.Break();
+            }
+
         }
 
         public override bool UpdateFromGame(Game game)

--- a/src/Data/GOG/GOGProduct.cs
+++ b/src/Data/GOG/GOGProduct.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+
+namespace DLSS_Swapper.Data.GOG;
+
+class GOGProduct
+{
+    [JsonPropertyName("id")]
+    public long Id { get; set; }
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [JsonPropertyName("images")]
+    public GOGProductImages? Images { get; set; }
+}
+
+class GOGProductImages
+{
+    [JsonPropertyName("background")]
+    public string? Background { get; set; }
+
+    [JsonPropertyName("logo")]
+    public string? Logo { get; set; }
+
+    [JsonPropertyName("logo2x")]
+    public string? Logo2x { get; set; }
+
+    [JsonPropertyName("icon")]
+    public string? Icon { get; set; }
+
+    [JsonPropertyName("sidebarIcon")]
+    public string? SidebarIcon { get; set; }
+
+    [JsonPropertyName("sidebarIcon2x")]
+    public string? SidebarIcon2x { get; set; }
+
+    [JsonPropertyName("menuNotificationAv")]
+    public string? MenuNotificationAv { get; set; }
+
+    [JsonPropertyName("menuNotificationAv2")]
+    public string? MenuNotificationAv2 { get; set; }
+}


### PR DESCRIPTION
## Description of Changes

Allows loading of cover images if GOG Galaxy is not installed by using various endpoints to load game data.
<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
#279
