### PR TITLE
Bugfix/import dlls

### DIFF
--- a/src/.editorconfig
+++ b/src/.editorconfig
@@ -1,6 +1,6 @@
 ### From: https://github.com/dotnet/aspnetcore/blob/main/.editorconfig
 ### Last sync: c323953
-### Disabled: CA2007, IDE0073, SYSLIB1054
+### Disabled: CA2007, IDE0073, SYSLIB1054, CA2201
 ; EditorConfig to support per-solution formatting.
 ; Use the EditorConfig VS add-in to make this work.
 ; http://editorconfig.org/
@@ -264,7 +264,7 @@ dotnet_diagnostic.CA2022.severity = warning
 dotnet_diagnostic.CA2200.severity = warning
 
 # CA2201: Do not raise reserved exception types
-dotnet_diagnostic.CA2201.severity = warning
+# dotnet_diagnostic.CA2201.severity = warning
 
 # CA2208: Instantiate argument exceptions correctly
 dotnet_diagnostic.CA2208.severity = warning

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -47,9 +47,6 @@ namespace DLSS_Swapper
 
         public static App CurrentApp => (App)Application.Current;
 
-        //internal Manifest Manifest { get; } = new Manifest();
-        internal Manifest ImportedManifest { get; } = new Manifest();
-
         internal HttpClient? _httpClient;
         public HttpClient HttpClient
         {

--- a/src/DLSS Swapper.csproj
+++ b/src/DLSS Swapper.csproj
@@ -104,6 +104,8 @@
     <None Remove="Themes\FakeContentDialogStyle.xaml" />
     <None Remove="UserControls\DLLPickerControl.xaml" />
     <None Remove="UserControls\GameControl.xaml" />
+    <None Remove="UserControls\ImportDLLSummaryControl.xaml" />
+    <None Remove="UserControls\ImportSystemDisabledView.xaml" />
     <None Remove="UserControls\ManuallyAddGameControl.xaml" />
     <None Remove="UserControls\MultipleDLLsFoundControl.xaml" />
     <None Remove="UserControls\NewDLLsControl.xaml" />
@@ -299,6 +301,12 @@
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
+        <Page Update="UserControls\ImportDLLSummaryControl.xaml">
+          <Generator>MSBuild:Compile</Generator>
+        </Page>
+        <Page Update="UserControls\ImportSystemDisabledView.xaml">
+          <Generator>MSBuild:Compile</Generator>
+        </Page>
         <Page Update="DiagnosticsWindow.xaml">
           <Generator>MSBuild:Compile</Generator>
         </Page>

--- a/src/Data/DLLImportResult.cs
+++ b/src/Data/DLLImportResult.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DLSS_Swapper.Data;
+
+public record DLLImportResult
+{
+    public bool Success { get; private set; }
+    public string FilePath { get; private set; } = string.Empty;
+    public string Message { get; private set; } = string.Empty;
+    public bool ImportedAsDownload { get; private set; }
+
+    private DLLImportResult()
+    {
+
+    }
+
+    public static DLLImportResult FromSucces(string filePath, string message, bool importedAsDownload)
+    {
+        var dllImportResult = new DLLImportResult()
+        {
+            Success = true,
+            FilePath = filePath,
+            ImportedAsDownload = importedAsDownload,
+            Message = message,
+        };
+        return dllImportResult;
+    }
+
+    public static DLLImportResult FromFail(string filePath, string message)
+    {
+        var dllImportResult = new DLLImportResult()
+        {
+            Success = true,
+            FilePath = filePath,
+            Message = message,
+        };
+        return dllImportResult;
+    }
+
+    public override string ToString()
+    {
+        return $"Success: {Success}, FilePath: {FilePath}, ImportedAsDownload: {ImportedAsDownload}, Message: {Message}";
+    }
+}

--- a/src/Data/DLLManager.cs
+++ b/src/Data/DLLManager.cs
@@ -759,4 +759,61 @@ internal class DLLManager
             return DLLImportResult.FromFail(zippedDllFullName ?? filePath, err.Message);
         }
     }
+
+    internal void DeleteImportedDllRecord(DLLRecord dllRecord)
+    {
+        ObservableCollection<DLLRecord>? recordList = null;
+        List<DLLRecord>? importedRecordList = null;
+
+        if (dllRecord.AssetType == GameAssetType.DLSS)
+        {
+            recordList = DLSSRecords;
+            importedRecordList = ImportedManifest?.DLSS;
+        }
+        else if (dllRecord.AssetType == GameAssetType.DLSS_G)
+        {
+            recordList = DLSSGRecords;
+            importedRecordList = ImportedManifest?.DLSS_G;
+        }
+        else if (dllRecord.AssetType == GameAssetType.DLSS_D)
+        {
+            recordList = DLSSDRecords;
+            importedRecordList = ImportedManifest?.DLSS_D;
+        }
+        else if (dllRecord.AssetType == GameAssetType.FSR_31_DX12)
+        {
+            recordList = FSR31DX12Records;
+            importedRecordList = ImportedManifest?.FSR_31_DX12;
+        }
+        else if (dllRecord.AssetType == GameAssetType.FSR_31_VK)
+        {
+            recordList = FSR31VKRecords;
+            importedRecordList = ImportedManifest?.FSR_31_VK;
+        }
+        else if (dllRecord.AssetType == GameAssetType.XeSS)
+        {
+            recordList = XeSSRecords;
+            importedRecordList = ImportedManifest?.XeSS;
+        }
+        else if (dllRecord.AssetType == GameAssetType.XeLL)
+        {
+            recordList = XeLLRecords;
+            importedRecordList = ImportedManifest?.XeLL;
+        }
+        else if (dllRecord.AssetType == GameAssetType.XeSS_FG)
+        {
+            recordList = XeSSFGRecords;
+            importedRecordList = ImportedManifest?.XeSS_FG;
+        }
+
+        if (recordList is null)
+        {
+            // For some reason we couldn't get the recordList, is this a new DLL type?
+            Debugger.Break();
+            return;
+        }
+
+        recordList.Remove(dllRecord);
+        importedRecordList?.Remove(dllRecord);
+    }
 }

--- a/src/Data/DLLRecord.cs
+++ b/src/Data/DLLRecord.cs
@@ -148,6 +148,11 @@ namespace DLSS_Swapper.Data
                 return -1;
             }
 
+            if (string.IsNullOrWhiteSpace(MD5Hash) == false && MD5Hash == other.MD5Hash)
+            {
+                return 0;
+            }
+
             if (VersionNumber == other.VersionNumber)
             {
                 if (IsDevFile == other.IsDevFile)
@@ -329,6 +334,5 @@ namespace DLSS_Swapper.Data
                 _ => string.Empty,
             };
         }
-
     }
 }

--- a/src/Data/DLLRecord.cs
+++ b/src/Data/DLLRecord.cs
@@ -334,5 +334,30 @@ namespace DLSS_Swapper.Data
                 _ => string.Empty,
             };
         }
+
+        internal void CopyFrom(DLLRecord newDllRecord)
+        {
+            Version = newDllRecord.Version;
+            VersionNumber = newDllRecord.VersionNumber;
+            InternalName = newDllRecord.InternalName;
+            AdditionalLabel = newDllRecord.AdditionalLabel;
+            MD5Hash = newDllRecord.MD5Hash;
+            ZipMD5Hash = newDllRecord.ZipMD5Hash;
+            DownloadUrl = newDllRecord.DownloadUrl;
+            FileDescription = newDllRecord.FileDescription;
+            SignedDateTime = newDllRecord.SignedDateTime;
+            IsSignatureValid = newDllRecord.IsSignatureValid;
+            IsDevFile = newDllRecord.IsDevFile;
+            FileSize = newDllRecord.FileSize;
+            ZipFileSize = newDllRecord.ZipFileSize;
+            LocalRecord = newDllRecord.LocalRecord;
+            AssetType = newDllRecord.AssetType;
+
+            NotifyPropertyChanged(nameof(FullName));
+            _displayVersion = string.Empty;
+            NotifyPropertyChanged(nameof(DisplayVersion));
+            NotifyPropertyChanged(nameof(DisplayName));
+        }
     }
+
 }

--- a/src/Data/DLLRecord.cs
+++ b/src/Data/DLLRecord.cs
@@ -29,6 +29,13 @@ namespace DLSS_Swapper.Data
         [JsonPropertyName("md5_hash")]
         public string MD5Hash { get; set; } = string.Empty;
 
+        /// <summary>
+        /// This hash is not guaranteed to be the same as the hash on the zip on the disk.
+        /// It is used during download to validate a successful download. However if you
+        /// import a DLL that exists in the manifest we will then create the zip for that
+        /// file. Doing so will cause the new generateed zip hash and this entry in the 
+        /// manifest to differ.
+        /// </summary>
         [JsonPropertyName("zip_md5_hash")]
         public string ZipMD5Hash { get; set; } = string.Empty;
 
@@ -271,6 +278,10 @@ namespace DLSS_Swapper.Data
             }
         }
 
+        internal string GetExpectedZipName()
+        {
+            return $"{GetRecordSimpleType()}_v{Version}_{MD5Hash}.zip";
+        }
 
         /*
         internal static DLSSRecord FromImportedFile(string fileName)

--- a/src/Data/GitHub/GitHubUpdater.cs
+++ b/src/Data/GitHub/GitHubUpdater.cs
@@ -27,31 +27,70 @@ namespace DLSS_Swapper.Data.GitHub
         /// Queries GitHub and returns the latest GitHubRelease object, or null if the request failed.
         /// </summary>
         /// <returns>Latest GitHubRelease object, or null if the request failed</returns>
-        internal async Task<GitHubRelease?> FetchLatestRelease()
+        internal async Task<GitHubRelease?> FetchLatestRelease(bool forceCheck)
         {
-            try
+            var shouldDownload = true;
+            var releasesFile = Storage.GetReleasesPath();
+            if (File.Exists(releasesFile))
             {
-                using (var memoryStream = new MemoryStream())
+                var fileInfo = new FileInfo(releasesFile);
+                var lastModifiedTime = DateTime.Now - fileInfo.LastWriteTime;
+                if (lastModifiedTime.TotalMinutes < 30)
                 {
-                    var fileDownloader = new FileDownloader("https://api.github.com/repos/beeradmoore/dlss-swapper/releases/latest", 0);
-                    await fileDownloader.DownloadFileToStreamAsync(memoryStream).ConfigureAwait(false);
-                    memoryStream.Position = 0;
-                    var githubRelease = JsonSerializer.Deserialize(memoryStream, SourceGenerationContext.Default.GitHubRelease);
-                    if (githubRelease is null)
-                    {
-                        throw new Exception("Could not load GitHub release data.");
-                    }
+                    shouldDownload = false;
 
-                    return githubRelease;
+                    // If we are not downloading and we are not forced to check then return the existing object.
+                    if (forceCheck == false)
+                    {
+                        using (var fileStream = File.OpenRead(releasesFile))
+                        {
+                            var githubRelease = JsonSerializer.Deserialize(fileStream, SourceGenerationContext.Default.GitHubRelease);
+                            if (githubRelease is not null)
+                            {
+                                return githubRelease;
+                            }
+                        }
+                    }
                 }
             }
-            catch (Exception err)
+
+            if (shouldDownload == true || forceCheck == true)
             {
-                // NOOP
-                Logger.Error(err);
-                Debugger.Break();
-                return null;
+                try
+                {
+                    using (var memoryStream = new MemoryStream())
+                    {
+                        var fileDownloader = new FileDownloader("https://api.github.com/repos/beeradmoore/dlss-swapper/releases/latest", 0);
+                        await fileDownloader.DownloadFileToStreamAsync(memoryStream).ConfigureAwait(false);
+
+                        memoryStream.Position = 0;
+
+                        var githubRelease = JsonSerializer.Deserialize(memoryStream, SourceGenerationContext.Default.GitHubRelease);
+                        if (githubRelease is null)
+                        {
+                            throw new Exception("Could not load GitHub release data.");
+                        }
+
+                        memoryStream.Position = 0;
+
+                        // If we did load the json, save it to disk.
+                        using (var fileStream = File.Create(releasesFile))
+                        {
+                            await memoryStream.CopyToAsync(fileStream).ConfigureAwait(false);
+                        }
+
+                        return githubRelease;
+                    }
+                }
+                catch (Exception err)
+                {
+                    // NOOP
+                    Logger.Error(err);
+                    return null;
+                }
             }
+
+            return null;
         }
 
         internal async Task<GitHubRelease?> GetReleaseFromTag(string tag)
@@ -85,9 +124,9 @@ namespace DLSS_Swapper.Data.GitHub
         /// Queries GitHub and returns a GitHubRelease only if a newer version was detected, otherwise null
         /// </summary>
         /// <returns>GitHubRelease object if an update is available, otherwise null.</returns>
-        internal async Task<GitHubRelease?> CheckForNewGitHubRelease()
+        internal async Task<GitHubRelease?> CheckForNewGitHubRelease(bool forceCheck)
         {
-            var latestRelease = await FetchLatestRelease().ConfigureAwait(false);
+            var latestRelease = await FetchLatestRelease(forceCheck).ConfigureAwait(false);
             if (latestRelease is null)
             {
                 return null;

--- a/src/Data/LocalRecord.cs
+++ b/src/Data/LocalRecord.cs
@@ -38,7 +38,7 @@ public partial class LocalRecord : ObservableObject, IEquatable<LocalRecord>
 
     }
 
-    public static LocalRecord FromExpectedPath(string expectedPath, bool imported = false)
+    public static LocalRecord FromExpectedPath(string expectedPath, bool isImported = false)
     {
         var localRecord = new LocalRecord()
         {
@@ -48,10 +48,7 @@ public partial class LocalRecord : ObservableObject, IEquatable<LocalRecord>
         if (File.Exists(expectedPath))
         {
             localRecord.IsDownloaded = true;
-            if (imported)
-            {
-                localRecord.IsImported = true;
-            }
+            localRecord.IsImported = isImported;
         }
 
         return localRecord;

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -332,11 +332,9 @@ If this keeps happening please file an report in our issue tracker on GitHub.",
 
             // We are now ready to show the games list.
             LoadingStackPanel.Visibility = Visibility.Collapsed;
-#if DEBUG
-            GoToPage("Library");
-#else
+
             GoToPage("Games");
-#endif
+
             // TODO: Disabled because CommunityToolkit.WinUI.Helpers.SystemInformation.Instance.IsAppUpdated throws exceptions for unpackaged apps.
             /*
             if (releaseNotesTask is not null)

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -238,9 +238,10 @@ namespace DLSS_Swapper
             var newUpdateTask = gitHubUpdater.CheckForNewGitHubRelease();
 
 
+            await DLLManager.Instance.LoadImportedManifestAsync();
+
             // Load from cache, or download if not found.
             var loadDlssRecrodsTask = LoadDLLRecordsAsync();
-            var loadImportedDlssRecordsTask = LoadImportedManifestAsync();
 
 
             if (Settings.Instance.HasShownMultiplayerWarning == false)
@@ -282,7 +283,17 @@ DLSS Swapper will close now.",
                 Close();
             }
 
-            await loadImportedDlssRecordsTask;
+            if (DLLManager.Instance.ImportedManifest is null)
+            {
+                var dialog = new EasyContentDialog(MainNavigationView.XamlRoot)
+                {
+                    Title = "Could not load imported DLLs",
+                    DefaultButton = ContentDialogButton.Close,
+                    Content = new ImportSystemDisabledView(),
+                    CloseButtonText = "Close",
+                };
+                await dialog.ShowAsync();
+            }
 
             FilterDLLRecords();
             //await App.CurrentApp.LoadLocalRecordsAsync();
@@ -384,25 +395,6 @@ DLSS Swapper will close now.",
             }
         }
 
-        // Previously: LoadImportedDLSSRecordsAsync
-        internal async Task LoadImportedManifestAsync()
-        {
-            var manifest = await Storage.LoadImportedManifestJsonAsync();
-            if (manifest is not null)
-            {
-                UpdateImportedManifestList(manifest);
-            }
-        }
-
-        // Previously: UpdateImportedDLSSRecordsList
-        internal void UpdateImportedManifestList(Manifest importedManifest)
-        {
-            // TODO: Reimplement
-            /*
-            App.CurrentApp.ImportedDLSSRecords.Clear();
-            App.CurrentApp.ImportedDLSSRecords.AddRange(localDlssRecords);
-            */
-        }
 
         /// <summary>
         /// Attempts to load manifest.json from dlss-swapper-manifest-builder repository.

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -234,7 +234,7 @@ namespace DLSS_Swapper
             var gitHubUpdater = new Data.GitHub.GitHubUpdater();
 
             // If this is a GitHub build check if there is a new version.
-            var newUpdateTask = gitHubUpdater.CheckForNewGitHubRelease();
+            var newUpdateTask = gitHubUpdater.CheckForNewGitHubRelease(false);
 
             await DLLManager.Instance.LoadManifestsAsync();
 

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -296,8 +296,6 @@ DLSS Swapper will close now.",
             }
 
             FilterDLLRecords();
-            //await App.CurrentApp.LoadLocalRecordsAsync();
-            DLLManager.Instance.LoadLocalRecords();
 
             // We are now ready to show the games list.
             LoadingStackPanel.Visibility = Visibility.Collapsed;
@@ -384,7 +382,7 @@ DLSS Swapper will close now.",
                 }
                 else
                 {
-                    DLLManager.Instance.UpdateDLLRecordLists(manifest);
+                    await DLLManager.Instance.UpdateDLLRecordListsAsync(manifest);
                 }
                 return true;
             }
@@ -419,10 +417,8 @@ DLSS Swapper will close now.",
                     {
                         throw new Exception("Could not deserialize manifest.json.");
                     }
-                    DLLManager.Instance.UpdateDLLRecordLists(manifest);
-                    //await UpdateDLSSRecordsListAsync(items);
+                    await DLLManager.Instance.UpdateDLLRecordListsAsync(manifest);
 
-                    memoryStream.Position = 0;
                     try
                     {
                         await Storage.SaveManifestJsonAsync(manifest);

--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -234,14 +234,9 @@ namespace DLSS_Swapper
             var gitHubUpdater = new Data.GitHub.GitHubUpdater();
 
             // If this is a GitHub build check if there is a new version.
-            // Lazy blocks to allow mul
             var newUpdateTask = gitHubUpdater.CheckForNewGitHubRelease();
 
-
-            await DLLManager.Instance.LoadImportedManifestAsync();
-
-            // Load from cache, or download if not found.
-            var loadDlssRecrodsTask = LoadDLLRecordsAsync();
+            await DLLManager.Instance.LoadManifestsAsync();
 
 
             if (Settings.Instance.HasShownMultiplayerWarning == false)
@@ -259,28 +254,63 @@ namespace DLSS_Swapper
             }
 
 
-            var didLoadDlssRecords = await loadDlssRecrodsTask;
-            if (didLoadDlssRecords == false)
+            if (DLLManager.Instance.HasLoadedManifest() == false)
             {
                 var dialog = new EasyContentDialog(MainNavigationView.XamlRoot)
                 {
                     Title = "Error",
                     CloseButtonText = "Close",
-                    PrimaryButtonText = "Github Issues",
+                    PrimaryButtonText = "GitHub issues",
+                    SecondaryButtonText = "Update manifest",
                     DefaultButton = ContentDialogButton.Primary,
-                    Content = @"We were unable to load manifest.json from your computer or from the internet. 
+                    Content = @"We were unable to load manifest.json from your computer.
 
-If this keeps happening please file an report in our issue tracker on Github.
-
-DLSS Swapper will close now.",
+If this keeps happening please file an report in our issue tracker on GitHub.",
                 };
+                var shouldClose = true;
+
                 var response = await dialog.ShowAsync();
                 if (response == ContentDialogResult.Primary)
                 {
                     await Launcher.LaunchUriAsync(new Uri("https://github.com/beeradmoore/dlss-swapper/issues"));
                 }
+                else if (response is ContentDialogResult.Secondary)
+                {
+                    dialog = new EasyContentDialog(MainNavigationView.XamlRoot)
+                    {
+                        Title = "Attempting to update",
+                        DefaultButton = ContentDialogButton.Close,
+                        Content = new ProgressRing()
+                        {
+                            IsActive = true,
+                            IsIndeterminate = true,
+                        },
+                    };
 
-                Close();
+                    var updateTask = DLLManager.Instance.UpdateManifestAsync();
+                    _ = dialog.ShowAsync();
+                    await updateTask;
+                    dialog.Hide();
+
+                    if (DLLManager.Instance.HasLoadedManifest() == true)
+                    {
+                        shouldClose = false;
+                    }
+                }
+
+                if (shouldClose)
+                {
+                    dialog = new EasyContentDialog(MainNavigationView.XamlRoot)
+                    {
+                        Title = "DLSS Swapper must close",
+                        CloseButtonText = "Close",
+                        DefaultButton = ContentDialogButton.Close,
+                        Content = "DLSS Swapper was not able to load its manifest file. It will now close.",
+                    };
+                    await dialog.ShowAsync();
+
+                    Close();
+                }
             }
 
             if (DLLManager.Instance.ImportedManifest is null)
@@ -295,13 +325,18 @@ DLSS Swapper will close now.",
                 await dialog.ShowAsync();
             }
 
-            FilterDLLRecords();
+            //FilterDLLRecords();
+
+            // Yeet this into the void and let it load in the background.
+            _ = DLLManager.Instance.UpdateManifestIfOldAsync();
 
             // We are now ready to show the games list.
             LoadingStackPanel.Visibility = Visibility.Collapsed;
+#if DEBUG
+            GoToPage("Library");
+#else
             GoToPage("Games");
-
-
+#endif
             // TODO: Disabled because CommunityToolkit.WinUI.Helpers.SystemInformation.Instance.IsAppUpdated throws exceptions for unpackaged apps.
             /*
             if (releaseNotesTask is not null)
@@ -314,6 +349,7 @@ DLSS Swapper will close now.",
             }
             */
 
+            // TODO: What happens if you have no internet
             await newUpdateTask;
             if (newUpdateTask.Result is not null)
             {
@@ -349,96 +385,6 @@ DLSS Swapper will close now.",
             CurrentDLSSRecords.AddRange(newDlssRecordsList);
             */
 
-        }
-
-        /// <summary>
-        /// Attempts to load DLSS records from disk or from the web depending what happened.
-        /// </summary>
-        /// <returns>True if we expect there are now valid DLSS records loaded into memory.</returns>
-        // Previously LoadDLSSRecordsAsync
-        async Task<bool> LoadDLLRecordsAsync()
-        {
-            // Only auto check for updates once every 12 hours.
-            var timeSinceLastUpdate = DateTimeOffset.Now - Settings.Instance.LastRecordsRefresh;
-            if (timeSinceLastUpdate.TotalMinutes > 5)
-            {
-                var didUpdate = await UpdateManifestAsync();
-                if (didUpdate)
-                {
-                    // If we did upda
-                    return true;
-                }
-            }
-
-            try
-            {
-                // If we were unable to auto-load lets try load cached.
-                var manifest = await Storage.LoadManifestJsonAsync();
-
-                // If manifest could not be loaded then we should attempt to upload dlss_records from the dlss-archive.
-                if (manifest is null || manifest.DLSS?.Any() == false)
-                {
-                    return await UpdateManifestAsync();
-                }
-                else
-                {
-                    await DLLManager.Instance.UpdateDLLRecordListsAsync(manifest);
-                }
-                return true;
-            }
-            catch (Exception err)
-            {
-                Logger.Error(err);
-                return false;
-            }
-        }
-
-
-        /// <summary>
-        /// Attempts to load manifest.json from dlss-swapper-manifest-builder repository.
-        /// </summary>
-        /// <returns>True if the dlss recrods manifest was downloaded and saved successfully</returns>
-        internal async Task<bool> UpdateManifestAsync()
-        {
-            try
-            {
-                using (var memoryStream = new MemoryStream())
-                {
-                    // TODO: Check how quickly this takes to timeout if there is no internet connection. Consider 
-                    // adding a "fast UpdateManifest" which will quit early if we were unable to load in 10sec 
-                    // which would then fall back to loading local.
-                    var fileDownloader = new FileDownloader("https://raw.githubusercontent.com/beeradmoore/dlss-swapper-manifest-builder/refs/heads/main/manifest.json", 0);
-                    await fileDownloader.DownloadFileToStreamAsync(memoryStream);
-
-                    memoryStream.Position = 0;
-
-                    var manifest = await JsonSerializer.DeserializeAsync(memoryStream, SourceGenerationContext.Default.Manifest);
-                    if (manifest is null)
-                    {
-                        throw new Exception("Could not deserialize manifest.json.");
-                    }
-                    await DLLManager.Instance.UpdateDLLRecordListsAsync(manifest);
-
-                    try
-                    {
-                        await Storage.SaveManifestJsonAsync(manifest);
-                        // Update settings for auto refresh.
-                        Settings.Instance.LastRecordsRefresh = DateTime.Now;
-                        return true;
-                    }
-                    catch (Exception err)
-                    {
-                        Logger.Error(err);
-                    }
-                }
-            }
-            catch (Exception err)
-            {
-                Logger.Error(err);
-                Debugger.Break();
-            }
-
-            return false;
         }
 
 

--- a/src/Pages/LibraryPage.xaml
+++ b/src/Pages/LibraryPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="DLSS_Swapper.Pages.LibraryPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -7,11 +7,12 @@
     xmlns:ct_converters="using:CommunityToolkit.WinUI.Converters"
     xmlns:converters="using:DLSS_Swapper.Converters"
     xmlns:system="using:System"
+    xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
     xmlns:data="using:DLSS_Swapper.Data"
     mc:Ignorable="d"    
     NavigationCacheMode="Required"
     x:Name="thisPage">
-    
+
     <Page.Resources>
         <converters:DLSSStateVisibilityConverter x:Key="IsDownloadingConverter" DesierdState="Downloading" />
         <converters:DLSSStateVisibilityConverter x:Key="IsDownloadedConverter" DesierdState="Downloaded" />
@@ -21,7 +22,8 @@
         <converters:BytesToMegaBytesConverter x:Key="BytesToMegaBytesConverter" />
         <converters:TotalBytesVisbilityConverter x:Key="TotalBytesVisbilityConverter" />
     </Page.Resources>
-    
+
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="*" />
@@ -35,7 +37,11 @@
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="0" Padding="16,0,16,0">
-            <TextBlock Margin="16,0,0,0" Text="Library" TextWrapping="NoWrap" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center" />
+            <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Spacing="16">
+                <TextBlock Text="Library" Margin="16,0,0,0" TextWrapping="NoWrap" Style="{StaticResource TitleTextBlockStyle}" VerticalAlignment="Center" />
+                <muxc:ProgressRing IsActive="True" VerticalAlignment="Center" Visibility="{x:Bind ViewModel.IsRefreshing, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"  />
+            </StackPanel>
+            
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
                 <AppBarButton HorizontalAlignment="Right"  Label="Import" Command="{x:Bind ViewModel.ImportCommand}">
                     <AppBarButton.Content>
@@ -49,7 +55,7 @@
                 </AppBarButton>
                 <AppBarButton HorizontalAlignment="Right" Label="Refresh" Command="{x:Bind ViewModel.RefreshCommand}">
                     <AppBarButton.Content>
-                        <FontIcon Glyph="&#xE72C;"  />
+                        <FontIcon Glyph="&#xE72C;" />
                     </AppBarButton.Content>
                 </AppBarButton>
             </StackPanel>
@@ -66,19 +72,10 @@
 
 
         <ScrollViewer Grid.Row="2" HorizontalScrollMode="Enabled" VerticalScrollMode="Disabled" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Disabled">
-            <SelectorBar SelectionChanged="SelectorBar_SelectionChanged">
-                <SelectorBarItem x:Name="DLSS" Text="DLSS" IsSelected="True" Tag="{x:Bind data:GameAssetType.DLSS}" />
-                <SelectorBarItem x:Name="DLSS_FG" Text="DLSS Frame Generation" Tag="{x:Bind data:GameAssetType.DLSS_G}" />
-                <SelectorBarItem x:Name="DLSS_RR" Text="DLSS Ray Reconstruction" Tag="{x:Bind data:GameAssetType.DLSS_D}" />
-                <SelectorBarItem x:Name="FSR_31_DX12" Text="FSR 3.1 (DirectX 12)" Tag="{x:Bind data:GameAssetType.FSR_31_DX12}" />
-                <SelectorBarItem x:Name="FSR_31_VK" Text="FSR 3.1 (Vulkan)" Tag="{x:Bind data:GameAssetType.FSR_31_VK}"/>
-                <SelectorBarItem x:Name="XeSS" Text="XeSS" Tag="{x:Bind data:GameAssetType.XeSS}" />
-                <SelectorBarItem x:Name="XeSS_FG" Text="XeSS Frame Generation" Tag="{x:Bind data:GameAssetType.XeSS_FG}" />
-                <SelectorBarItem x:Name="XeLL" Text="XeLL" Tag="{x:Bind data:GameAssetType.XeLL}" />
-            </SelectorBar>
+            <SelectorBar x:Name="UpscalerSelectorBar" SelectedItem="{x:Bind ViewModel.SelectedSelectorBarItem, Mode=TwoWay}" />
         </ScrollViewer>
 
-        <GridView Grid.Row="3" x:Name="MainGridView" Margin="16" SizeChanged="MainGridView_SizeChanged" ItemsSource="{x:Bind ViewModel.SelectedLibraryList, Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="True" ItemClick="MainGridView_ItemClick">
+        <GridView Grid.Row="3" x:Name="MainGridView" Margin="16,0,16,0" SizeChanged="MainGridView_SizeChanged" ItemsSource="{x:Bind ViewModel.SelectedLibraryList, Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="True" ItemClick="MainGridView_ItemClick">
           
             <GridView.ItemsPanel>
                 <ItemsPanelTemplate>

--- a/src/Pages/LibraryPage.xaml.cs
+++ b/src/Pages/LibraryPage.xaml.cs
@@ -41,14 +41,6 @@ namespace DLSS_Swapper.Pages
             ((ItemsWrapGrid)MainGridView.ItemsPanelRoot).ItemWidth = (e.NewSize.Width / columns) - 1;
         }
 
-        private void SelectorBar_SelectionChanged(SelectorBar sender, SelectorBarSelectionChangedEventArgs args)
-        {
-            if (sender.SelectedItem.Tag is GameAssetType gameAssetType)
-            {
-                ViewModel.SelectLibrary(gameAssetType);
-            }
-        }
-
         private void MainGridView_ItemClick(object sender, ItemClickEventArgs e)
         {
             if (e.ClickedItem is DLLRecord dllRecord)

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -654,10 +654,11 @@ Only import dlls from sources you trust.",
         var assetTypeName = DLLManager.Instance.GetAssetTypeName(record.AssetType);
         var dialog = new EasyContentDialog(libraryPage.XamlRoot)
         {
+            Title = "Delete DLL",
+            Content = $"Are you sure you want to delete {assetTypeName} v{record.Version}?",
             PrimaryButtonText = "Delete",
             CloseButtonText = "Cancel",
             DefaultButton = ContentDialogButton.Primary,
-            Content = $"Delete {assetTypeName} v{record.Version}?",
         };
         var response = await dialog.ShowAsync();
         if (response == ContentDialogResult.Primary)

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -113,14 +113,8 @@ public partial class LibraryPageModel : CommunityToolkit.Mvvm.ComponentModel.Obs
         allDllRecords.AddRange(DLLManager.Instance.FSR31DX12Records.Where(x => x.LocalRecord?.IsDownloaded == true));
         allDllRecords.AddRange(DLLManager.Instance.FSR31VKRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
         allDllRecords.AddRange(DLLManager.Instance.XeSSRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
-        allDllRecords.AddRange(DLLManager.Instance.XeLLRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
         allDllRecords.AddRange(DLLManager.Instance.XeSSFGRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
-
-        // TODO: Add local records
-        if (DLLManager.Instance.ImportedManifest is not null)
-        {
-            //allDllRecords.AddRange(DLLManager.Instance.ImportedManifest.DLSS);
-        }
+        allDllRecords.AddRange(DLLManager.Instance.XeLLRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
 
         if (allDllRecords.Count == 0)
         {

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -669,9 +669,8 @@ Only import dlls from sources you trust.",
                 if (record.LocalRecord.IsImported)
                 {
                     // TODO: What to do here?
-                    //DLLManager.Instance.DeleteImportedDllRecord(record)
-                    //App.CurrentApp.ImportedDLSSRecords.Remove(record);
-                    await DLLManager.SaveImportedManifestJsonAsync();
+                    DLLManager.Instance.DeleteImportedDllRecord(record);
+                    await DLLManager.Instance.SaveImportedManifestJsonAsync();
                     App.CurrentApp.MainWindow.FilterDLLRecords();
                 }
                 else

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -44,7 +44,6 @@ public partial class LibraryPageModel : CommunityToolkit.Mvvm.ComponentModel.Obs
         if (didUpdate)
         {
             App.CurrentApp.MainWindow.FilterDLLRecords();
-            DLLManager.Instance.LoadLocalRecords();
         }
         else
         {
@@ -626,7 +625,7 @@ Only import dlls from sources you trust.",
 
         if (importResults.Any(x => x.Success == true))
         {
-            await DLLManager.SaveImportedManifestJsonAsync();
+            await DLLManager.Instance.SaveImportedManifestJsonAsync();
             App.CurrentApp.MainWindow.FilterDLLRecords();
         }
 

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -9,6 +9,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using AsyncAwaitBestPractices.MVVM;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -16,10 +17,12 @@ using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using CommunityToolkit.WinUI.Collections;
 using DLSS_Swapper.Data;
+using DLSS_Swapper.Extensions;
 using DLSS_Swapper.UserControls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Documents;
 
 namespace DLSS_Swapper.Pages;
 
@@ -71,7 +74,10 @@ public partial class LibraryPageModel : CommunityToolkit.Mvvm.ComponentModel.Obs
         allDllRecords.AddRange(DLLManager.Instance.XeSSFGRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
 
         // TODO: Add local records
-        //allDlssRecords.AddRange(App.CurrentApp.ImportedDLSSRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
+        if (DLLManager.Instance.ImportedManifest is not null)
+        {
+            //allDllRecords.AddRange(DLLManager.Instance.ImportedManifest.DLSS);
+        }
 
         if (allDllRecords.Count == 0)
         {
@@ -242,122 +248,22 @@ public partial class LibraryPageModel : CommunityToolkit.Mvvm.ComponentModel.Obs
     }
 
 
-    void ImportDLL(string filename)
-    {
-        // TODO: Reimplement
-        /*
-        var versionInfo = FileVersionInfo.GetVersionInfo(filename);
-
-        // Can't import DLSS v3 dlls at this time.
-        if (versionInfo.FileDescription?.Contains("DLSS-G", StringComparison.InvariantCultureIgnoreCase) == true)
-        {
-            throw new Exception($"Could not import \"{filename}\", appears to be a DLSS 3 (frame generation) file.");
-        }
-
-        // Can't import if it isn't a DLSS dll file.
-        if (versionInfo.FileDescription?.Contains("DLSS", StringComparison.InvariantCultureIgnoreCase) == false)
-        {
-            throw new Exception($"Could not import \"{filename}\", does not appear to be a DLSS dll.");
-        }
-
-        var isTrusted = WinTrust.VerifyEmbeddedSignature(filename);
-
-        // Don't do anything with untrusted dlls.
-        if (Settings.Instance.AllowUntrusted == false && isTrusted == false)
-        {
-            throw new Exception($"Could not import \"{filename}\", file is not trusted by Windows.");
-        }
-
-        var dllHash = versionInfo.GetMD5Hash();
-
-        var existingImportedDlls = App.CurrentApp.ImportedDLSSRecords.Where(x => string.Equals(x.MD5Hash, dllHash, StringComparison.InvariantCultureIgnoreCase));
-        // If the dll is already imported don't import it again.
-        if (existingImportedDlls.Any())
-        {
-            throw new Exception($"Could not import \"{filename}\", file appears to have been imported previously.");
-        }
-
-        var fileInfo = new FileInfo(filename);
-        var zipFilename = $"{versionInfo.GetFormattedFileVersion()}_{dllHash}.zip";
-        var finalZipPath = Path.Combine(Storage.GetStorageFolder(), "imported_dlss_zip", zipFilename);
-        Storage.CreateDirectoryForFileIfNotExists(finalZipPath);
-
-
-        // The plan here was to check if importing is equivilant of downloading the file and if so consider it the downloaded file.
-        // The zip hash (and zip filesize) does not match if we create the zip here so it seems odd to have that as a value.
-        // We could potentially just consider the ziphash only used for downloading and not on disk validation.
-        //var existingDLSSRecord = App.CurrentApp.DLSSRecords.GetRecordFromHash(dllHash);
-        //if (existingDLSSRecord is not null)
-        //{
-        //    var tempExtractPath = Path.Combine(Storage.GetTemp(), "import");
-        //    Storage.CreateDirectoryIfNotExists(tempExtractPath);
-        //    var tempZipFile = Path.Combine(tempExtractPath, Path.GetFileNameWithoutExtension(filename)) + ".zip";
-        //    using (var zipFile = File.Open(tempZipFile, FileMode.Create))
-        //    {
-        //        using (var zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Create, true))
-        //        {
-        //            zipArchive.CreateEntryFromFile(filename, Path.GetFileName("nvngx_dlss.dll"));
-        //        }
-        //        zipFile.Position = 0;
-        //        var size = zipFile.Length;
-        //        // Once again, MD5 should never be used to check if a file has been tampered with.
-        //        // We are simply using it to check the integrity of the downloaded/extracted file.
-        //        using (var md5 = MD5.Create())
-        //        {
-        //            var hash = md5.ComputeHash(zipFile);
-        //            var zipHash = BitConverter.ToString(hash).Replace("-", "").ToUpperInvariant();
-        //        }
-        //    }
-        //}
-
-        var tempExtractPath = Path.Combine(Storage.GetTemp(), "import");
-        Storage.CreateDirectoryIfNotExists(tempExtractPath);
-
-        var tempZipFile = Path.Combine(tempExtractPath, zipFilename);
-
-        var dlssRecord = new DLLRecord()
-        {
-            Version = versionInfo.GetFormattedFileVersion(),
-            VersionNumber = versionInfo.GetFileVersionNumber(),
-            MD5Hash = dllHash,
-            FileSize = fileInfo.Length,
-            ZipFileSize = 0,
-            ZipMD5Hash = string.Empty,
-            IsSignatureValid = isTrusted,
-        };
-
-        using (var zipFile = File.Open(tempZipFile, FileMode.Create))
-        {
-            using (var zipArchive = new ZipArchive(zipFile, ZipArchiveMode.Create, true))
-            {
-                zipArchive.CreateEntryFromFile(filename, Path.GetFileName("nvngx_dlss.dll"));
-            }
-
-            zipFile.Position = 0;
-
-            dlssRecord.ZipFileSize = zipFile.Length;
-            // Once again, MD5 should never be used to check if a file has been tampered with.
-            // We are simply using it to check the integrity of the downloaded/extracted file.
-            using (var md5 = MD5.Create())
-            {
-                var hash = md5.ComputeHash(zipFile);
-                dlssRecord.ZipMD5Hash = BitConverter.ToString(hash).Replace("-", "").ToUpperInvariant();
-            }
-        }
-
-        // Move new record to where it should live in DLSS Swapper app directory.
-        File.Move(tempZipFile, finalZipPath, true);
-
-        dlssRecord.LocalRecord = LocalRecord.FromExpectedPath(finalZipPath, true);
-
-        // Add our new record.
-        App.CurrentApp.ImportedDLSSRecords.Add(dlssRecord);
-        */
-    }
-
     [RelayCommand]
     async Task ImportAsync()
     {
+        if (DLLManager.Instance.ImportedManifest is null)
+        {
+            var couldNotImportDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = "Could not load imported DLLs",
+                DefaultButton = ContentDialogButton.Close,
+                Content = new ImportSystemDisabledView(),
+                CloseButtonText = "Close",
+            };
+            await couldNotImportDialog.ShowAsync();
+            return;
+        }
+
         if (Settings.Instance.HasShownWarning == false)
         {
             var warningDialog = new EasyContentDialog(libraryPage.XamlRoot)
@@ -376,167 +282,364 @@ Only import dlls from sources you trust.",
             Settings.Instance.HasShownWarning = true;
         }
 
-        var sorryDialog = new EasyContentDialog(libraryPage.XamlRoot)
-        {
-            Title = "Sorry",
-            CloseButtonText = "Okay",
-            DefaultButton = ContentDialogButton.Close,
-            Content = @"Import system is currently broken, but it is on the roadmap to be fixed.",
-        };
-        await sorryDialog.ShowAsync();
-
-        /*
+        
         var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.CurrentApp.MainWindow);
         var openPicker = new Windows.Storage.Pickers.FileOpenPicker();
         openPicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
         openPicker.FileTypeFilter.Add(".dll");
         openPicker.FileTypeFilter.Add(".zip");
         WinRT.Interop.InitializeWithWindow.Initialize(openPicker, hwnd);
-        var openFile = await openPicker.PickSingleFileAsync();
+        var openFileList = await openPicker.PickMultipleFilesAsync();
 
         // User cancelled.
-        if (openFile is null)
+        if (openFileList is null || openFileList.Count == 0)
         {
             return;
         }
 
-
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var filesProgressBar = new ProgressBar()
         {
-            PrimaryButtonText = "Import",
-            CloseButtonText = "Cancel",
-            DefaultButton = ContentDialogButton.Primary,
-            Title = "Reminder",
-            Content = $"Only import DLLs from sources you trust.",
+            IsIndeterminate = true
         };
-        var response = await dialog.ShowAsync();
-        if (response == ContentDialogResult.Primary)
+        var dllInZipProgressBar = new ProgressBar()
         {
-            if (File.Exists(openFile.Path) == false)
+            IsIndeterminate = true
+        };
+        var progressTextBlock = new TextBlock()
+        {
+            Text = string.Empty,
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        progressTextBlock.Inlines.Add(new Run() { Text = "Processed DLLs: " });
+        var progressRun = new Run() { Text = "0" };
+        progressTextBlock.Inlines.Add(progressRun);
+        var progressStackPanel = new StackPanel()
+        {
+            Spacing = 16,
+            Orientation = Orientation.Vertical,
+            Children =
             {
-                return;
+                filesProgressBar,
+                dllInZipProgressBar,
+                progressTextBlock,
             }
+        };
 
-            var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = "Importing",
+            // I would like this to be a progress ring but for some reason the ring will not show.
+            Content = progressStackPanel,
+        };
+        _ = loadingDialog.ShowAsync();
+
+        var taskCompletionSource = new TaskCompletionSource<List<DLLImportResult>>();
+
+        bool HandleLocalDLLRecordZip(string importedPath, DLLRecord dllRecord, List<DLLImportResult> importResults)
+        {
+            if (dllRecord.LocalRecord is not null)
             {
-                Title = "Importing",
-                // I would like this to be a progress ring but for some reason the ring will not show.
-                Content = new ProgressBar()
+                if (File.Exists(dllRecord.LocalRecord.ExpectedPath))
                 {
-                    IsIndeterminate = true,
-                },
-            };
-            _ = loadingDialog.ShowAsync();
-
-            // Give UI time to update and show import screen.
-            await Task.Delay(50);
-
-            // Used only if we import a zip
-            var tempExtractPath = Path.Combine(Storage.GetTemp(), "import");
-
-            var importPartiallyFailed = false;
-            try
-            {
-                var importSuccessCount = 0;
-                var importFailureCount = 0;
-
-                if (openFile.Path.EndsWith(".zip"))
-                {
-                    using (var archive = ZipFile.OpenRead(openFile.Path))
-                    {
-                        var zippedDlls = archive.Entries.Where(x => x.Name.EndsWith(".dll")).ToArray();
-                        if (zippedDlls.Length == 0)
-                        {
-                            throw new Exception("Zip did not contain any dlls..");
-                        }
-
-                        Storage.CreateDirectoryIfNotExists(tempExtractPath);
-
-                        foreach (var zippedDll in zippedDlls)
-                        {
-                            var tempFile = Path.Combine(tempExtractPath, $"nvngx_dlss_{Guid.NewGuid().ToString("D")}.dll");
-                            zippedDll.ExtractToFile(tempFile);
-
-                            try
-                            {
-                                ImportDLL(tempFile);
-                                ++importSuccessCount;
-                            }
-                            catch (Exception)
-                            {
-                                importPartiallyFailed = true;
-                                ++importFailureCount;
-                            }
-
-                            // Clean up temp file.
-                            File.Delete(tempFile);
-                        }
-                    }
-
-                    // We still save if some records have been imported.
-                    if (importSuccessCount > 0)
-                    {
-                        await Storage.SaveImportedManifestJsonAsync();
-                        App.CurrentApp.MainWindow.FilterDLLRecords();
-                    }
-
-                    if (importPartiallyFailed)
-                    {
-                        throw new Exception($"From the zip import, {importSuccessCount} DLSS dlls succeeded and {importFailureCount} failed.");
-                    }
-                }
-                else
-                {
-                    ImportDLL(openFile.Path);
-                    ++importSuccessCount;
-
-                    await Storage.SaveImportedManifestJsonAsync();
-                    App.CurrentApp.MainWindow.FilterDLLRecords();
+                    importResults.Add(DLLImportResult.FromSucces(dllRecord.LocalRecord.ExpectedPath, "Already downloaded.", true));
+                    return true;
                 }
 
-                loadingDialog.Hide();
-
-                dialog = new EasyContentDialog(libraryPage.XamlRoot)
+                File.Copy(importedPath, dllRecord.LocalRecord.ExpectedPath);
+                App.CurrentApp.RunOnUIThread(() =>
                 {
-                    CloseButtonText = "Okay",
-                    DefaultButton = ContentDialogButton.Close,
-                    Title = "Success",
-                    Content = $"Imported {importSuccessCount} DLSS dll record{(importSuccessCount == 1 ? string.Empty : "s")}.",
-                };
-                await dialog.ShowAsync();
+                    var localRecord = dllRecord.LocalRecord;
+                    localRecord.IsDownloaded = true;
+                    dllRecord.LocalRecord = null;
+                    dllRecord.LocalRecord = localRecord;
+                });
+                importResults.Add(DLLImportResult.FromSucces(importedPath, "Imported as existing DLL record.", true));
+                return true;
             }
-            catch (Exception err)
+            else
             {
-                loadingDialog.Hide();
-
-                // Clean up tempExtractPath if it exists
-                if (Directory.Exists(tempExtractPath))
-                {
-                    try
-                    {
-                        Directory.Delete(tempExtractPath, true);
-                    }
-                    catch (Exception err2)
-                    {
-                        Logger.Error(err2);
-                    }
-                }
-
-                Logger.Error(err);
-
-
-                // TODO: Button to open error log
-                dialog = new EasyContentDialog(libraryPage.XamlRoot)
-                {
-                    CloseButtonText = "Okay",
-                    DefaultButton = ContentDialogButton.Close,
-                    Title = "Error",
-                    Content = $"Could not import record. Please see your error log for more information.",
-                };
-                await dialog.ShowAsync();
+                // This should never happen.
+                Logger.Error("dllRecord.LocalRecord is null");
+                Debugger.Break();
+                return false;
             }
         }
-        */
+
+        if (openFileList.Count == 1)
+        {
+            filesProgressBar.Visibility = Visibility.Collapsed;
+        }
+        else
+        {
+            filesProgressBar.IsIndeterminate = false;
+        }
+
+        filesProgressBar.Value = 0;
+        filesProgressBar.Maximum = openFileList.Count;
+
+        var selectedFilesProcessed = 0;
+        var totalDllsProcessed = 0;
+
+        ThreadPool.QueueUserWorkItem((stateInfo) =>
+        {
+            var importResults = new List<DLLImportResult>();
+
+            // Used only if we import a zip
+            var tempExtractPath = Path.Combine(Storage.GetTemp(), "import", Guid.NewGuid().ToString("D"));
+            Storage.CreateDirectoryIfNotExists(tempExtractPath);
+
+           
+            foreach (var importFile in openFileList)
+            {
+                ++selectedFilesProcessed;
+                App.CurrentApp.RunOnUIThread(() =>
+                {
+                    filesProgressBar.Value = selectedFilesProcessed;
+                });
+
+                if (importFile is null || File.Exists(importFile.Path) == false)
+                {
+                    importResults.Add(DLLImportResult.FromFail(importFile?.Path ?? string.Empty, "File not found."));
+                    continue;
+                }
+
+                try
+                {
+                    if (importFile.Path.EndsWith(".zip", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        // If we are importing a zip, first check if its hash is one 
+                        // that we expect.Then we can just bypass everything.                        
+                        var newZipHash = string.Empty;
+                        using (var fileStream = File.OpenRead(importFile.Path))
+                        {
+                            newZipHash = fileStream.GetMD5Hash();
+                        }
+
+                        if (string.IsNullOrWhiteSpace(newZipHash) == false)
+                        {
+                            var dlssRecord = DLLManager.Instance.DLSSRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (dlssRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, dlssRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var dlssDRecord = DLLManager.Instance.DLSSDRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (dlssDRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, dlssDRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var dlssGRecord = DLLManager.Instance.DLSSGRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (dlssGRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, dlssGRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var fsr31dx12Record = DLLManager.Instance.FSR31DX12Records.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (fsr31dx12Record is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, fsr31dx12Record, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var fsr32vkRecord = DLLManager.Instance.FSR31VKRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (fsr32vkRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, fsr32vkRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var xessRecord = DLLManager.Instance.XeSSRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (xessRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, xessRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var xellRecord = DLLManager.Instance.XeLLRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (xellRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, xellRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+
+                            var xessFGRecord = DLLManager.Instance.XeSSFGRecords.FirstOrDefault(x => string.Equals(x.ZipMD5Hash, newZipHash, StringComparison.InvariantCultureIgnoreCase));
+                            if (xessFGRecord is not null)
+                            {
+                                if (HandleLocalDLLRecordZip(importFile.Path, xessFGRecord, importResults))
+                                {
+                                    ++totalDllsProcessed;
+                                    App.CurrentApp.RunOnUIThread(() =>
+                                    {
+                                        progressRun.Text = totalDllsProcessed.ToString();
+                                    });
+                                    continue;
+                                }
+                            }
+                        }
+
+
+                        // Now that we know the zip itself is not a known zip we will extract each DLL and import them.
+                        using (var archive = ZipFile.OpenRead(importFile.Path))
+                        {
+                            var zippedDlls = archive.Entries.Where(x => x.Name.EndsWith(".dll")).ToArray();
+                            if (zippedDlls.Length == 0)
+                            {
+                                throw new Exception("Zip did not contain any dlls.");
+                            }
+
+                            var dllsInZip = zippedDlls.Length;
+                            var processedDllsInZip = 0;
+
+                            App.CurrentApp.RunOnUIThread(() =>
+                            {
+                                dllInZipProgressBar.IsIndeterminate = false;
+                                dllInZipProgressBar.Value = processedDllsInZip;
+                                dllInZipProgressBar.Maximum = dllsInZip;
+                            });
+
+                            foreach (var zippedDll in zippedDlls)
+                            {
+                                var tempFile = Path.Combine(tempExtractPath, zippedDll.Name);
+                                zippedDll.ExtractToFile(tempFile, true);
+
+                                ++processedDllsInZip;
+                                ++totalDllsProcessed;
+                                App.CurrentApp.RunOnUIThread(() =>
+                                {
+                                    dllInZipProgressBar.Value = processedDllsInZip;
+                                    progressRun.Text = totalDllsProcessed.ToString();
+                                });
+
+
+                                try
+                                {
+                                    // In future when DLLs will have multiple per bundle we will have to extract them all and pass them as a list.
+                                    importResults.Add(DLLManager.Instance.ImportDll(tempFile, zippedDll.FullName));
+                                }
+                                catch (Exception err)
+                                {
+                                    Logger.Error(err);
+                                    importResults.Add(DLLImportResult.FromFail(zippedDll.FullName, err.Message));
+                                }
+
+                                // Clean up temp file.
+                                File.Delete(tempFile);
+                            }
+                        }
+                    }
+                    else if (importFile.Path.EndsWith(".dll", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        try
+                        {
+                            importResults.Add(DLLManager.Instance.ImportDll(importFile.Path));
+                        }
+                        catch (Exception err)
+                        {
+                            Logger.Error(err);
+                            importResults.Add(DLLImportResult.FromFail(importFile.Path, err.Message));
+                        }
+
+                        ++totalDllsProcessed;
+                        App.CurrentApp.RunOnUIThread(() =>
+                        {
+                            progressRun.Text = totalDllsProcessed.ToString();
+                        });
+                    }
+                }
+                catch (Exception err)
+                {
+                    Logger.Error(err);
+                    importResults.Add(DLLImportResult.FromFail(importFile.Path, err.Message));
+                }
+            }
+
+            // Clean up tempExtractPath if it exists
+            if (Directory.Exists(tempExtractPath))
+            {
+                try
+                {
+                    Directory.Delete(tempExtractPath, true);
+                }
+                catch (Exception err2)
+                {
+                    Logger.Error(err2);
+                }
+            }
+
+            taskCompletionSource.SetResult(importResults);
+        });
+
+        var importResults = await taskCompletionSource.Task;
+
+        if (importResults.Any(x => x.Success == true))
+        {
+            await DLLManager.SaveImportedManifestJsonAsync();
+            App.CurrentApp.MainWindow.FilterDLLRecords();
+        }
+
+        loadingDialog.Hide();
+  
+        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            CloseButtonText = "Okay",
+            DefaultButton = ContentDialogButton.Close,
+            Title = "Finished",
+            Content = new ImportDLLSummaryControl(importResults),
+        };
+        await dialog.ShowAsync();
     }
 
     [RelayCommand]
@@ -567,7 +670,7 @@ Only import dlls from sources you trust.",
                     // TODO: What to do here?
                     //DLLManager.Instance.DeleteImportedDllRecord(record)
                     //App.CurrentApp.ImportedDLSSRecords.Remove(record);
-                    await Storage.SaveImportedManifestJsonAsync();
+                    await DLLManager.SaveImportedManifestJsonAsync();
                     App.CurrentApp.MainWindow.FilterDLLRecords();
                 }
                 else
@@ -695,7 +798,6 @@ Only import dlls from sources you trust.",
 
     internal void SelectLibrary(GameAssetType gameAssetType)
     {
-
         var newList = gameAssetType switch
         {
             GameAssetType.DLSS => DLLManager.Instance.DLSSRecords,

--- a/src/Pages/SettingsPage.xaml
+++ b/src/Pages/SettingsPage.xaml
@@ -1,4 +1,4 @@
-﻿<Page
+<Page
     x:Class="DLSS_Swapper.Pages.SettingsPage"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -143,7 +143,7 @@
                                 
                 <RichTextBlock Margin="0,24,0,0">
                     <Paragraph Margin="0,12,0,0">
-                        Github:
+                        GitHub:
                         <Hyperlink NavigateUri="https://github.com/beeradmoore/dlss-swapper">beeradmoore/dlss-swapper</Hyperlink>
                     </Paragraph>
                     <Paragraph Margin="0,0,0,0">

--- a/src/Pages/SettingsPageModel.cs
+++ b/src/Pages/SettingsPageModel.cs
@@ -186,7 +186,7 @@ internal partial class SettingsPageModel : ObservableObject
 
         await Task.Delay(2500);
         var githubUpdater = new Data.GitHub.GitHubUpdater();
-        var newUpdate = await githubUpdater.CheckForNewGitHubRelease();
+        var newUpdate = await githubUpdater.CheckForNewGitHubRelease(true);
 
         if (_weakPage.TryGetTarget(out SettingsPage? settingsPage))
         {

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -139,23 +139,6 @@ namespace DLSS_Swapper
             }
         }
 
-        DateTimeOffset _lastRecordsRefresh = DateTimeOffset.MinValue;
-        public DateTimeOffset LastRecordsRefresh
-        {
-            get { return _lastRecordsRefresh; }
-            set
-            {
-                if (_lastRecordsRefresh != value)
-                {
-                    _lastRecordsRefresh = value;
-                    if (_autoSave)
-                    {
-                        SaveJson();
-                    }
-                }
-            }
-        }
-
 
         ulong _lastPromptWasForVersion = 0L;
         public ulong LastPromptWasForVersion

--- a/src/Storage.cs
+++ b/src/Storage.cs
@@ -83,6 +83,11 @@ namespace DLSS_Swapper
             return Path.Combine(StoragePath, "image_cache");
         }
 
+        public static string GetReleasesPath()
+        {
+            return Path.Combine(GetDynamicJsonFolder(), "releases.json");
+        }
+
         public static string GetManifestPath()
         {
             return Path.Combine(GetDynamicJsonFolder(), "manifest.json");

--- a/src/Storage.cs
+++ b/src/Storage.cs
@@ -83,6 +83,11 @@ namespace DLSS_Swapper
             return Path.Combine(StoragePath, "image_cache");
         }
 
+        public static string GetImportedManifestPath()
+        {
+            return Path.Combine(GetDynamicJsonFolder(), "imported_manifest.json");
+        }
+
         /// <summary>
         /// When given a file path it will make the directory structure so that file is ready to be created in. A directory should not be passed to this. Use CreateDirectoryIfNotExists instead for that.
         /// </summary>
@@ -261,58 +266,10 @@ namespace DLSS_Swapper
         }
 
         /// <summary>
-        /// Loads an imported manifest file of all imported DLL records.
-        /// </summary>
-        /// <returns>Manifest object of imported DLL records. This will contain empty lists if no imported recrods were found.</returns>
-        // Previously: LoadImportedDLSSRecordsJsonAsync
-        internal static async Task<Manifest> LoadImportedManifestJsonAsync()
-        {
-            var importedDLSSRecordsFile = Path.Combine(GetDynamicJsonFolder(), "imported_manifest.json");
-            if (File.Exists(importedDLSSRecordsFile) == true)
-            {
-                try
-                {
-                    using (var stream = File.Open(importedDLSSRecordsFile, FileMode.Open))
-                    {
-                        var importedManifest = await JsonSerializer.DeserializeAsync(stream, SourceGenerationContext.Default.Manifest);
-                        if (importedManifest is not null)
-                        {
-                            return importedManifest;
-                        }
-                    }
-                }
-                catch (Exception err)
-                {
-                    Logger.Error(err);
-                }
-            }
-
-            // If we failed to load we return a blank manifest.
-            return new Manifest();
-        }
-
-        /// <summary>
         /// Saves the imported DLSS records to imported_manifest.json
         /// </summary>
         /// <returns></returns>
         // Previously: SaveImportedDLSSRecordsJsonAsync
-        internal static async Task<bool> SaveImportedManifestJsonAsync()
-        {
-            var importedManifestFile = Path.Combine(GetDynamicJsonFolder(), "imported_manifest.json");
-            CreateDirectoryForFileIfNotExists(importedManifestFile);
-            try
-            {
-                using (var stream = File.Open(importedManifestFile, FileMode.Create))
-                {
-                    await JsonSerializer.SerializeAsync(stream, App.CurrentApp.ImportedManifest, SourceGenerationContext.Default.Manifest);
-                }
-                return true;
-            }
-            catch (Exception err)
-            {
-                Logger.Error(err);
-                return false;
-            }
-        }
+    
     }
 }

--- a/src/UserControls/ImportDLLSummaryControl.xaml
+++ b/src/UserControls/ImportDLLSummaryControl.xaml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DLSS_Swapper.UserControls.ImportDLLSummaryControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DLSS_Swapper.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <StackPanel Orientation="Vertical">
+        <TextBlock>
+            <Run Text="Success: " FontWeight="Bold"></Run>
+            <Run Text="{x:Bind ViewModel.SuccessCount}" />
+        </TextBlock>
+        <TextBlock>
+            <Run Text="Failed: " FontWeight="Bold"></Run>
+            <Run Text="{x:Bind ViewModel.FailedCount}" />
+        </TextBlock>
+    </StackPanel>
+</UserControl>

--- a/src/UserControls/ImportDLLSummaryControl.xaml.cs
+++ b/src/UserControls/ImportDLLSummaryControl.xaml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+using DLSS_Swapper.Data;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace DLSS_Swapper.UserControls;
+
+public sealed partial class ImportDLLSummaryControl : UserControl
+{
+    ImportDLLSummaryControlModel ViewModel { get; }
+
+    public ImportDLLSummaryControl(IReadOnlyList<DLLImportResult> dllImportResults)
+    {
+        this.InitializeComponent();
+        ViewModel = new ImportDLLSummaryControlModel(dllImportResults);
+        DataContext = ViewModel;
+    }
+}

--- a/src/UserControls/ImportDLLSummaryControlModel.cs
+++ b/src/UserControls/ImportDLLSummaryControlModel.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DLSS_Swapper.Data;
+
+namespace DLSS_Swapper.UserControls;
+
+class ImportDLLSummaryControlModel
+{
+    public int SuccessCount { get; set; }
+    public int FailedCount { get; set; }
+
+    public ImportDLLSummaryControlModel(IReadOnlyList<DLLImportResult> dllImportResults)
+    {
+        SuccessCount = dllImportResults.Count(x => x.Success == true);
+        FailedCount = dllImportResults.Count(x => x.Success == false);
+
+        foreach (var dllImportResult in dllImportResults)
+        {
+            Logger.Verbose($"DLLImportResult: {dllImportResult.ToString()}");
+        }
+    }
+}

--- a/src/UserControls/ImportSystemDisabledView.xaml
+++ b/src/UserControls/ImportSystemDisabledView.xaml
@@ -8,7 +8,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
     <TextBlock TextWrapping="WrapWholeWords">
-        <Run> was an error loading the imported manifest file. To preserve your imported data, the importing functionality has been disabled until this is resolved. Please see </Run>
+        <Run>There was an error loading the imported manifest file. To preserve your imported data the importing functionality has been disabled until this is resolved. Please see </Run>
         <Hyperlink NavigateUri="https://github.com/beeradmoore/dlss-swapper/wiki/Troubleshooting#imported-manifest-file-could-not-be-loaded">troubleshooting guide</Hyperlink>
         <Run> for more information.</Run>
     </TextBlock>

--- a/src/UserControls/ImportSystemDisabledView.xaml
+++ b/src/UserControls/ImportSystemDisabledView.xaml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DLSS_Swapper.UserControls.ImportSystemDisabledView"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DLSS_Swapper.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+    <TextBlock TextWrapping="WrapWholeWords">
+        <Run> was an error loading the imported manifest file. To preserve your imported data, the importing functionality has been disabled until this is resolved. Please see </Run>
+        <Hyperlink NavigateUri="https://github.com/beeradmoore/dlss-swapper/wiki/Troubleshooting#imported-manifest-file-could-not-be-loaded">troubleshooting guide</Hyperlink>
+        <Run> for more information.</Run>
+    </TextBlock>
+</UserControl>

--- a/src/UserControls/ImportSystemDisabledView.xaml.cs
+++ b/src/UserControls/ImportSystemDisabledView.xaml.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Foundation;
+using Windows.Foundation.Collections;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Controls.Primitives;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using Microsoft.UI.Xaml.Navigation;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace DLSS_Swapper.UserControls
+{
+    public sealed partial class ImportSystemDisabledView : UserControl
+    {
+        public ImportSystemDisabledView()
+        {
+            this.InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
## Description of Changes

This fixes the broken DLL import system. It also adds a few improvements such as being able to import a zip containing multiple recrods, as well as being able to select multiple records at once from the file picker.

This change also overhauls how manifests are loaded and used to create the main `ObservableCollectionView`.

Failing to load manifests will now report an error and exit the app.

### Additional changes that should have been their own branches
- Disabled CA2201 in .editorconfig to not warn about using `Exception` class.
- Made the GitHub app update checker to still run on launch, but skip if it was ran within 30 minutes.
- Added loading indicator in library page much like games page.
- Changed library SelectorBar to be generated in code not in xaml. This paves the way for us to change the order of them in the future.
- Fixed padding at the bottom of the Library page 
- Fixed typos of "Github" to "GitHub"
- Improved wording aroud deleting a DLL record.


## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->
#317

<!-- Example:
#123
#345
-->
