### PR TITLE
[Bugfix] Refreshing game library on settings changed.

### DIFF
--- a/src/Data/GameManager.cs
+++ b/src/Data/GameManager.cs
@@ -293,9 +293,12 @@ internal partial class GameManager : ObservableObject
     {
         lock (gameLock)
         {
+            // TODO: Cancel loading of games here
             _synchronisedAllGames.Clear();
 
-            App.CurrentApp.RunOnUIThread(_allGames.Clear);
+            App.CurrentApp.RunOnUIThread(() => {
+                _allGames.Clear();
+            });
         }
     }
 

--- a/src/Data/GameManager.cs
+++ b/src/Data/GameManager.cs
@@ -289,6 +289,15 @@ internal partial class GameManager : ObservableObject
         }
     }
 
+    public void RemoveAllGames()
+    {
+        lock (gameLock)
+        {
+            _synchronisedAllGames.Clear();
+
+            App.CurrentApp.RunOnUIThread(_allGames.Clear);
+        }
+    }
 
     public TGame? GetGame<TGame>(string platformId) where TGame : Game
     {

--- a/src/Messages/GameLibrariesChangedMessage.cs
+++ b/src/Messages/GameLibrariesChangedMessage.cs
@@ -1,0 +1,10 @@
+using CommunityToolkit.Mvvm.Messaging.Messages;
+
+namespace DLSS_Swapper.Messages;
+
+internal class GameLibrariesChangedMessage : ValueChangedMessage<uint>
+{
+    public GameLibrariesChangedMessage(uint gameLibraries) : base(gameLibraries)
+    {
+    }
+}

--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -9,6 +9,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Transactions;
+using AsyncAwaitBestPractices;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using DLSS_Swapper.Data;
@@ -70,13 +71,20 @@ public partial class GameGridPageModel : ObservableObject
         _ => new FontIcon() { },
     };
 
-
-
+    private async void OnEnabledGameLibrariesChanged(object sender, EventArgs e)
+    {
+        IsGameListLoading = true;
+        IsDLSSLoading = true;
+        GameManager.Instance.RemoveAllGames();
+        await GameManager.Instance.LoadGamesFromCacheAsync();
+        IsGameListLoading = false;
+        IsDLSSLoading = false;
+    }
 
     public GameGridPageModel(GameGridPage gameGridPage)
     {
+        Settings.Instance.OnEnabledGameLibrariesChanged += OnEnabledGameLibrariesChanged;
         this.gameGridPage = gameGridPage;
-
         ApplyGameGroupFilter();
     }
 

--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -71,19 +71,9 @@ public partial class GameGridPageModel : ObservableObject
         _ => new FontIcon() { },
     };
 
-    private async void OnEnabledGameLibrariesChanged(object sender, EventArgs e)
-    {
-        IsGameListLoading = true;
-        IsDLSSLoading = true;
-        GameManager.Instance.RemoveAllGames();
-        await GameManager.Instance.LoadGamesFromCacheAsync();
-        IsGameListLoading = false;
-        IsDLSSLoading = false;
-    }
-
     public GameGridPageModel(GameGridPage gameGridPage)
     {
-        Settings.Instance.OnEnabledGameLibrariesChanged += OnEnabledGameLibrariesChanged;
+        Settings.Instance.EnabledGameLibrariesChanged += OnEnabledGameLibrariesChanged;
         this.gameGridPage = gameGridPage;
         ApplyGameGroupFilter();
     }
@@ -400,4 +390,13 @@ If you have checked these and your game is still not showing up there may be a b
         Settings.Instance.GameGridViewType = gameGridView;
     }
 
+    private async Task OnEnabledGameLibrariesChanged(object sender, EventArgs e)
+    {
+        IsGameListLoading = true;
+        IsDLSSLoading = true;
+        GameManager.Instance.RemoveAllGames();
+        await GameManager.Instance.LoadGamesFromCacheAsync();
+        IsGameListLoading = false;
+        IsDLSSLoading = false;
+    }
 }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -1,3 +1,4 @@
+using CommunityToolkit.Mvvm.Messaging;
 using DLSS_Swapper.Data;
 using DLSS_Swapper.Pages;
 using Microsoft.UI.Xaml;
@@ -14,8 +15,8 @@ namespace DLSS_Swapper
         static Settings? _instance = null;
 
         public static Settings Instance => _instance ??= Settings.FromJson();
-        public event EnabledGameLibrariesChangedHandler EnabledGameLibrariesChanged;
-        public delegate Task EnabledGameLibrariesChangedHandler(object sender, EventArgs e);
+        //public event EnabledGameLibrariesChangedHandler EnabledGameLibrariesChanged;
+        //public delegate Task EnabledGameLibrariesChangedHandler(object sender, EventArgs e);
 
         // We default this to false to prevent saves firing when loading from json.
         bool _autoSave = false;
@@ -195,8 +196,9 @@ namespace DLSS_Swapper
                     if (_autoSave)
                     {
                         SaveJson();
-                        EnabledGameLibrariesChanged?.Invoke(this, EventArgs.Empty);
                     }
+
+                    WeakReferenceMessenger.Default.Send(new Messages.GameLibrariesChangedMessage(_enabledGameLibraries));
                 }
             }
         }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -4,6 +4,7 @@ using Microsoft.UI.Xaml;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Windows.Graphics;
 
 namespace DLSS_Swapper
@@ -13,8 +14,8 @@ namespace DLSS_Swapper
         static Settings? _instance = null;
 
         public static Settings Instance => _instance ??= Settings.FromJson();
-        public event EnabledGameLibrariesChangedHandler OnEnabledGameLibrariesChanged;
-        public delegate void EnabledGameLibrariesChangedHandler(object sender, EventArgs e);
+        public event EnabledGameLibrariesChangedHandler EnabledGameLibrariesChanged;
+        public delegate Task EnabledGameLibrariesChangedHandler(object sender, EventArgs e);
 
         // We default this to false to prevent saves firing when loading from json.
         bool _autoSave = false;
@@ -211,7 +212,7 @@ namespace DLSS_Swapper
                     if (_autoSave)
                     {
                         SaveJson();
-                        OnEnabledGameLibrariesChanged?.Invoke(this, new EventArgs());
+                        EnabledGameLibrariesChanged?.Invoke(this, new EventArgs());
                     }
                 }
             }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -212,7 +212,7 @@ namespace DLSS_Swapper
                     if (_autoSave)
                     {
                         SaveJson();
-                        EnabledGameLibrariesChanged?.Invoke(this, new EventArgs());
+                        EnabledGameLibrariesChanged?.Invoke(this, EventArgs.Empty);
                     }
                 }
             }

--- a/src/Settings.cs
+++ b/src/Settings.cs
@@ -13,6 +13,8 @@ namespace DLSS_Swapper
         static Settings? _instance = null;
 
         public static Settings Instance => _instance ??= Settings.FromJson();
+        public event EnabledGameLibrariesChangedHandler OnEnabledGameLibrariesChanged;
+        public delegate void EnabledGameLibrariesChangedHandler(object sender, EventArgs e);
 
         // We default this to false to prevent saves firing when loading from json.
         bool _autoSave = false;
@@ -209,6 +211,7 @@ namespace DLSS_Swapper
                     if (_autoSave)
                     {
                         SaveJson();
+                        OnEnabledGameLibrariesChanged?.Invoke(this, new EventArgs());
                     }
                 }
             }


### PR DESCRIPTION
## Description of Changes

Changing settings reflects game library.

- [x] Bug fix

Building new list from cache shouldn't last long.
It's rebuilding the whole games library.

Another option is to compare settings enum after change with previous enum to get GameLibrary enum that was actually removed, and then pass it in event args to remove only elements from specified GameLibrary and get them back from the cache, but don't know if is it such a big deal.

## Issues Resolved
[#242](https://github.com/beeradmoore/dlss-swapper/issues/242)