### PR TITLE
Made removed game not appear

### DIFF
--- a/src/Data/BattleNet/BattleNetLibrary.cs
+++ b/src/Data/BattleNet/BattleNetLibrary.cs
@@ -191,7 +191,7 @@ internal partial class BattleNetLibrary : IGameLibrary
 
                 if (Directory.Exists(activeGame.InstallPath) == false)
                 {
-                    Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                    Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                     continue;
                 }
 
@@ -255,7 +255,7 @@ internal partial class BattleNetLibrary : IGameLibrary
 
                 if (Directory.Exists(game.InstallPath) == false)
                 {
-                    Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                    Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                     // We remove the list of known game assets, but not the game itself.
                     // Removing the game will remove its history, notes, and other data.
                     // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/BattleNet/BattleNetLibrary.cs
+++ b/src/Data/BattleNet/BattleNetLibrary.cs
@@ -189,6 +189,12 @@ internal partial class BattleNetLibrary : IGameLibrary
                     continue;
                 }
 
+                if (Directory.Exists(activeGame.InstallPath) == false)
+                {
+                    Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                    continue;
+                }
+
                 await activeGame.SaveToDatabaseAsync().ConfigureAwait(false);
 
                 if (cachedGame is null)
@@ -244,6 +250,16 @@ internal partial class BattleNetLibrary : IGameLibrary
             {
                 if (game.IsInIgnoredPath())
                 {
+                    continue;
+                }
+
+                if (Directory.Exists(game.InstallPath) == false)
+                {
+                    Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                    // We remove the list of known game assets, but not the game itself.
+                    // Removing the game will remove its history, notes, and other data.
+                    // We don't want to do this incase it is just a temporary issue.
+                    await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                     continue;
                 }
 

--- a/src/Data/BattleNet/BattleNetLibrary.cs
+++ b/src/Data/BattleNet/BattleNetLibrary.cs
@@ -258,7 +258,7 @@ internal partial class BattleNetLibrary : IGameLibrary
                     Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                     // We remove the list of known game assets, but not the game itself.
                     // Removing the game will remove its history, notes, and other data.
-                    // We don't want to do this incase it is just a temporary issue.
+                    // We don't want to do this in case it is just a temporary issue.
                     await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                     continue;
                 }

--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -230,7 +230,7 @@ namespace DLSS_Swapper.Data.EpicGamesStore
                         Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this incase it is just a temporary issue.
+                        // We don't want to do this in case it is just a temporary issue.
                         await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }

--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -160,7 +160,7 @@ namespace DLSS_Swapper.Data.EpicGamesStore
 
                     if (Directory.Exists(activeGame.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                         continue;
                     }
 
@@ -227,7 +227,7 @@ namespace DLSS_Swapper.Data.EpicGamesStore
 
                     if (Directory.Exists(game.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
                         // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -158,6 +158,12 @@ namespace DLSS_Swapper.Data.EpicGamesStore
                         continue;
                     }
 
+                    if (Directory.Exists(activeGame.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                        continue;
+                    }
+
                     await activeGame.SaveToDatabaseAsync();
 
                     // If the game is not from cache, force processing
@@ -216,6 +222,16 @@ namespace DLSS_Swapper.Data.EpicGamesStore
                 {
                     if (game.IsInIgnoredPath())
                     {
+                        continue;
+                    }
+
+                    if (Directory.Exists(game.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        // We remove the list of known game assets, but not the game itself.
+                        // Removing the game will remove its history, notes, and other data.
+                        // We don't want to do this incase it is just a temporary issue.
+                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Data/EpicGamesStore/LauncherInstalled.cs
+++ b/src/Data/EpicGamesStore/LauncherInstalled.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace DLSS_Swapper.Data.EpicGamesStore
 {
-    // Did not end up using LauncherInstalled.dat but keeping this here incase we ever do wish to.
+    // Did not end up using LauncherInstalled.dat but keeping this here in case we ever do wish to.
     /*
     internal class LauncherInstalled
     {

--- a/src/Data/GOG/GOGLibrary.cs
+++ b/src/Data/GOG/GOGLibrary.cs
@@ -126,6 +126,12 @@ namespace DLSS_Swapper.Data.GOG
                                 continue;
                             }
 
+                            if (Directory.Exists(activeGame.InstallPath) == false)
+                            {
+                                Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                                continue;
+                            }
+
                             // If the game is not from cache, force processing
                             if (cachedGame is null)
                             {
@@ -338,6 +344,16 @@ namespace DLSS_Swapper.Data.GOG
                 {
                     if (game.IsInIgnoredPath())
                     {
+                        continue;
+                    }
+
+                    if (Directory.Exists(game.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        // We remove the list of known game assets, but not the game itself.
+                        // Removing the game will remove its history, notes, and other data.
+                        // We don't want to do this incase it is just a temporary issue.
+                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Data/GOG/GOGLibrary.cs
+++ b/src/Data/GOG/GOGLibrary.cs
@@ -162,7 +162,7 @@ namespace DLSS_Swapper.Data.GOG
                 //await Task.Delay(1);
                 var db = new SQLiteAsyncConnection(storageFileLocation, SQLiteOpenFlags.ReadOnly);
 
-                // Default resource type for verticalCover images is 3. We default to this, but we also add try load it incase it changes.
+                // Default resource type for verticalCover images is 3. We default to this, but we also add try load it in case it changes.
                 var webCacheResourceTypeId = 3;
                 var webCacheResourceType = (await db.QueryAsync<WebCacheResourceType>("SELECT * FROM WebCacheResourceTypes WHERE type=?", "verticalCover").ConfigureAwait(false)).FirstOrDefault();
                 if (webCacheResourceType is not null)
@@ -170,7 +170,7 @@ namespace DLSS_Swapper.Data.GOG
                     webCacheResourceTypeId = webCacheResourceType.Id;
                 }
 
-                // Default resource type for originalImages is 378. We default to this, but we also add try load it incase it changes.
+                // Default resource type for originalImages is 378. We default to this, but we also add try load it in case it changes.
                 var gamePieceTypeId = 378;
                 var gamePieceType = (await db.QueryAsync<GamePieceType>("SELECT * FROM GamePieceTypes WHERE type=?", "originalImages").ConfigureAwait(false)).FirstOrDefault();
                 if (gamePieceType is not null)
@@ -352,7 +352,7 @@ namespace DLSS_Swapper.Data.GOG
                         Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this incase it is just a temporary issue.
+                        // We don't want to do this in case it is just a temporary issue.
                         await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }

--- a/src/Data/GOG/GOGLibrary.cs
+++ b/src/Data/GOG/GOGLibrary.cs
@@ -128,7 +128,7 @@ namespace DLSS_Swapper.Data.GOG
 
                             if (Directory.Exists(activeGame.InstallPath) == false)
                             {
-                                Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                                Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                                 continue;
                             }
 
@@ -349,7 +349,7 @@ namespace DLSS_Swapper.Data.GOG
 
                     if (Directory.Exists(game.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
                         // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/Game.cs
+++ b/src/Data/Game.cs
@@ -1407,7 +1407,7 @@ namespace DLSS_Swapper.Data
             }
             else
             {
-                // If there is no known current DLLs then we likely want to do a full reload incase the game got updated.
+                // If there is no known current DLLs then we likely want to do a full reload in case the game got updated.
                 // TODO: Also add a time last reloaded here.
                 NeedsProcessing = true;
                 return;

--- a/src/Data/Game.cs
+++ b/src/Data/Game.cs
@@ -1337,8 +1337,16 @@ namespace DLSS_Swapper.Data
                     CurrentXeSS_FG = gameAsset;
                 }
             }
-
         }
+
+        public async Task RemoveGameAssetsFromCacheAsync()
+        {
+            using (await Database.Instance.Mutex.LockAsync())
+            {
+                await Database.Instance.Connection.ExecuteAsync("DELETE FROM GameAsset WHERE id = ?", ID).ConfigureAwait(false);
+            }
+        }
+
         public async Task LoadGameAssetsFromCacheAsync()
         {
             await LoadCoverImageAsync();

--- a/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
+++ b/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
@@ -85,6 +85,16 @@ public class ManuallyAddedLibrary : IGameLibrary
                     continue;
                 }
 
+                if (Directory.Exists(game.InstallPath) == false)
+                {
+                    Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                    // We remove the list of known game assets, but not the game itself.
+                    // Removing the game will remove its history, notes, and other data.
+                    // We don't want to do this incase it is just a temporary issue.
+                    await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
+                    continue;
+                }
+
                 await game.LoadGameAssetsFromCacheAsync().ConfigureAwait(false);
                 GameManager.Instance.AddGame(game);
             }

--- a/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
+++ b/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
@@ -87,7 +87,7 @@ public class ManuallyAddedLibrary : IGameLibrary
 
                 if (Directory.Exists(game.InstallPath) == false)
                 {
-                    Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                    Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                     // We remove the list of known game assets, but not the game itself.
                     // Removing the game will remove its history, notes, and other data.
                     // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
+++ b/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
@@ -90,7 +90,7 @@ public class ManuallyAddedLibrary : IGameLibrary
                     Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                     // We remove the list of known game assets, but not the game itself.
                     // Removing the game will remove its history, notes, and other data.
-                    // We don't want to do this incase it is just a temporary issue.
+                    // We don't want to do this in case it is just a temporary issue.
                     await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                     continue;
                 }

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -190,7 +190,7 @@ namespace DLSS_Swapper.Data.Steam
 
                         if (Directory.Exists(activeGame.InstallPath) == false)
                         {
-                            Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                            Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                             continue;
                         }
 
@@ -281,7 +281,7 @@ namespace DLSS_Swapper.Data.Steam
 
                     if (Directory.Exists(game.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
                         // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -284,7 +284,7 @@ namespace DLSS_Swapper.Data.Steam
                         Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this incase it is just a temporary issue.
+                        // We don't want to do this in case it is just a temporary issue.
                         await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -188,6 +188,12 @@ namespace DLSS_Swapper.Data.Steam
                             continue;
                         }
 
+                        if (Directory.Exists(activeGame.InstallPath) == false)
+                        {
+                            Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                            continue;
+                        }
+
                         await activeGame.SaveToDatabaseAsync().ConfigureAwait(false);
 
                         // If the game is not from cache, force processing
@@ -270,6 +276,16 @@ namespace DLSS_Swapper.Data.Steam
                 {
                     if (game.IsInIgnoredPath())
                     {
+                        continue;
+                    }
+
+                    if (Directory.Exists(game.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        // We remove the list of known game assets, but not the game itself.
+                        // Removing the game will remove its history, notes, and other data.
+                        // We don't want to do this incase it is just a temporary issue.
+                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
+++ b/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
@@ -226,6 +226,12 @@ namespace DLSS_Swapper.Data.UbisoftConnect
                                     continue;
                                 }
 
+                                if (Directory.Exists(activeGame.InstallPath) == false)
+                                {
+                                    Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                                    continue;
+                                }
+
                                 await activeGame.SaveToDatabaseAsync();
 
                                 // If the game is not from cache, force processing
@@ -478,6 +484,16 @@ namespace DLSS_Swapper.Data.UbisoftConnect
                 {
                     if (game.IsInIgnoredPath())
                     {
+                        continue;
+                    }
+
+                    if (Directory.Exists(game.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        // We remove the list of known game assets, but not the game itself.
+                        // Removing the game will remove its history, notes, and other data.
+                        // We don't want to do this incase it is just a temporary issue.
+                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
+++ b/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
@@ -228,7 +228,7 @@ namespace DLSS_Swapper.Data.UbisoftConnect
 
                                 if (Directory.Exists(activeGame.InstallPath) == false)
                                 {
-                                    Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                                    Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                                     continue;
                                 }
 
@@ -489,7 +489,7 @@ namespace DLSS_Swapper.Data.UbisoftConnect
 
                     if (Directory.Exists(game.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
                         // We don't want to do this in case it is just a temporary issue.

--- a/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
+++ b/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
@@ -492,7 +492,7 @@ namespace DLSS_Swapper.Data.UbisoftConnect
                         Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this incase it is just a temporary issue.
+                        // We don't want to do this in case it is just a temporary issue.
                         await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }

--- a/src/Data/Xbox/XboxLibrary.cs
+++ b/src/Data/Xbox/XboxLibrary.cs
@@ -281,7 +281,7 @@ namespace DLSS_Swapper.Data.Xbox
                         Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this incase it is just a temporary issue.
+                        // We don't want to do this in case it is just a temporary issue.
                         await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }

--- a/src/Data/Xbox/XboxLibrary.cs
+++ b/src/Data/Xbox/XboxLibrary.cs
@@ -216,6 +216,12 @@ namespace DLSS_Swapper.Data.Xbox
                             continue;
                         }
 
+                        if (Directory.Exists(activeGame.InstallPath) == false)
+                        {
+                            Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                            continue;
+                        }
+
                         await activeGame.SetLocalHeaderImagesAsync(gameNamesToFindPackages[packageName]);
                         //await game.UpdateCacheImageAsync();
                         await activeGame.SaveToDatabaseAsync();
@@ -267,6 +273,16 @@ namespace DLSS_Swapper.Data.Xbox
                 {
                     if (game.IsInIgnoredPath())
                     {
+                        continue;
+                    }
+
+                    if (Directory.Exists(game.InstallPath) == false)
+                    {
+                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        // We remove the list of known game assets, but not the game itself.
+                        // Removing the game will remove its history, notes, and other data.
+                        // We don't want to do this incase it is just a temporary issue.
+                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
                         continue;
                     }
 

--- a/src/Data/Xbox/XboxLibrary.cs
+++ b/src/Data/Xbox/XboxLibrary.cs
@@ -218,7 +218,7 @@ namespace DLSS_Swapper.Data.Xbox
 
                         if (Directory.Exists(activeGame.InstallPath) == false)
                         {
-                            Logger.Error($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
+                            Logger.Warning($"{Name} library could not load game {activeGame.Title} ({activeGame.PlatformId}) because install path does not exist: {activeGame.InstallPath}");
                             continue;
                         }
 
@@ -278,7 +278,7 @@ namespace DLSS_Swapper.Data.Xbox
 
                     if (Directory.Exists(game.InstallPath) == false)
                     {
-                        Logger.Error($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
                         // We remove the list of known game assets, but not the game itself.
                         // Removing the game will remove its history, notes, and other data.
                         // We don't want to do this in case it is just a temporary issue.

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -882,7 +882,7 @@ Only import dlls from sources you trust.",
 
             if (saveFile is not null)
             {
-                // This will likley not be seen, but keeping it here incase export is very slow (eg. copy over very slow network).
+                // This will likley not be seen, but keeping it here in case export is very slow (eg. copy over very slow network).
                 _ = exportingDialog.ShowAsync();
 
                 // Give UI time to update and show import screen.

--- a/src/ThemeWatcher.cs
+++ b/src/ThemeWatcher.cs
@@ -53,7 +53,7 @@ namespace DLSS_Swapper
 
         public void Start()
         {
-            // Cleanup incase start is called twice.
+            // Cleanup in case start is called twice.
             Stop();
 
 


### PR DESCRIPTION
## Description of Changes

When loading games from cache or libraries, if the install path is not found we don't proceed to add the game to the games list.

When this is triggered loading from cache we also remove GameAsset objects. This is because if the disappearing game folder is from a temporary issue we don't reset the game data (notes, history, etc). This data will be rebuilt if/when the game reappears.

<!-- Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments. -->

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
#537
