### PR TITLE
Added reload game button

### DIFF
--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -520,6 +520,9 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="General_Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="General_Reload" xml:space="preserve">
+    <value>Reload</value>
+  </data>
   <data name="General_Remove" xml:space="preserve">
     <value>Remove</value>
   </data>

--- a/src/UserControls/GameControl.xaml
+++ b/src/UserControls/GameControl.xaml
@@ -66,6 +66,13 @@
                         <FontIcon Style="{StaticResource SagoeFluentIconsFontIcon}" Glyph="{Binding Game.IsFavourite, Converter={StaticResource FavouriteGlyphConverter}}"/>
                     </Button.Content>
                 </Button>
+                
+                <Button Command="{Binding ReloadGameCommand}" ToolTipService.ToolTip="{Binding TranslationProperties.ReloadText, Mode=OneWay}">
+                    <Button.Content>
+                        <FontIcon Style="{StaticResource SagoeFluentIconsFontIcon}" Glyph="&#xE72C;"/>
+                    </Button.Content>
+                </Button>
+                
             </StackPanel>
         </ControlTemplate>
 

--- a/src/UserControls/GameControlModelTranslationProperties.cs
+++ b/src/UserControls/GameControlModelTranslationProperties.cs
@@ -51,4 +51,6 @@ public class GameControlModelTranslationProperties : LocalizedViewModelBase
     [TranslationProperty]
     public string DLSSPresetInfoTooltipText => ResourceHelper.GetString("GamePage_DLSSPresetInfo_Tooltip");
 
+    [TranslationProperty]
+    public string ReloadText => ResourceHelper.GetString("General_Reload");
 }


### PR DESCRIPTION
## Description of Changes

There exists an issue where if a game exists and is already scanned but then the game adds a new upscaler that the new upscaler is not detected until a full game reload is done.

This is a partial fix for the issue as it adds a "reload" button onto the game page itself. That way it is possible to reload a single game and not every game in your library.

<!-- Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments. -->

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->

#374
