### PR TITLE
Prevented import/export/add game from working when running as admin

### DIFF
--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -107,6 +107,19 @@ public partial class GameGridPageModel : ObservableObject
     [RelayCommand]
     async Task AddManualGameButtonAsync()
     {
+        if (Environment.IsPrivilegedProcess)
+        {
+            var errorDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = ResourceHelper.GetString("General_FeatureNotSupportedWhenAdmin"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+
         if (Settings.Instance.DontShowManuallyAddingGamesNotice == false)
         {
             var dontShowAgainCheckbox = new CheckBox()
@@ -169,7 +182,6 @@ public partial class GameGridPageModel : ObservableObject
 
     async Task AddGameManually()
     {
-
         TextBlockBuilder textBlockBuilder = new TextBlockBuilder(ResourceHelper.GetString("GamesPage_ManuallyAdding_InfoHtml"));
 
         if (Settings.Instance.HasShownAddGameFolderMessage == false)

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -102,6 +102,19 @@ public partial class LibraryPageModel : ObservableObject
     [RelayCommand]
     async Task ExportAllAsync()
     {
+        if (Environment.IsPrivilegedProcess)
+        {
+            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = ResourceHelper.GetString("General_FeatureNotSupportedWhenAdmin"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+
         // Check that there are records to export first.
         var allDllRecords = new List<DLLRecord>();
         allDllRecords.AddRange(DLLManager.Instance.DLSSRecords.Where(x => x.LocalRecord?.IsDownloaded == true));
@@ -347,6 +360,19 @@ public partial class LibraryPageModel : ObservableObject
     [RelayCommand]
     async Task ImportAsync()
     {
+        if (Environment.IsPrivilegedProcess)
+        {
+            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = ResourceHelper.GetString("General_FeatureNotSupportedWhenAdmin"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+
         if (DLLManager.Instance.ImportedManifest is null)
         {
             var couldNotImportDialog = new EasyContentDialog(libraryPage.XamlRoot)
@@ -838,6 +864,19 @@ public partial class LibraryPageModel : ObservableObject
     [RelayCommand]
     async Task ExportRecordAsync(DLLRecord dllRecord)
     {
+        if (Environment.IsPrivilegedProcess)
+        {
+            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = ResourceHelper.GetString("General_FeatureNotSupportedWhenAdmin"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+
         if (dllRecord.LocalRecord is null)
         {
             return;


### PR DESCRIPTION
## Description of Changes

This does not fix the issue of being able to add game, import/export dlls when running as admin. However it will error instead of crash which will reduce the support required from my end so I can focus on other things.

Folder 
<!-- Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments. -->

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
