### PR TITLE
Delete DLL backups on game update

### DIFF
--- a/src/Converters/GameHistoryEventTypeToLabelConverter.cs
+++ b/src/Converters/GameHistoryEventTypeToLabelConverter.cs
@@ -13,8 +13,11 @@ internal class GameHistoryEventTypeToLabelConverter : IValueConverter
         {
             return eventType switch
             {
-                GameHistoryEventType.DLLSwap => ResourceHelper.GetString("GameHistoryEventType_DLLSwap"),
+                GameHistoryEventType.DLLSwapped => ResourceHelper.GetString("GameHistoryEventType_DLLSwapped"),
                 GameHistoryEventType.DLLReset => ResourceHelper.GetString("GameHistoryEventType_DLLReset"),
+                GameHistoryEventType.DLLDetected => ResourceHelper.GetString("GameHistoryEventType_DLLDetected"),
+                GameHistoryEventType.DLLChangedExternally => ResourceHelper.GetString("GameHistoryEventType_DLLChangedExternally"),
+                GameHistoryEventType.DLLBackupRemoved => ResourceHelper.GetString("GameHistoryEventType_DLLBackupRemoved"),
                 _ => ResourceHelper.GetString("General_Unknown"),
             };
         }

--- a/src/Data/GameHistory.cs
+++ b/src/Data/GameHistory.cs
@@ -1,8 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SQLite;
 
 namespace DLSS_Swapper.Data;
@@ -10,8 +6,11 @@ namespace DLSS_Swapper.Data;
 public enum GameHistoryEventType
 {
     Unknown,
-    DLLSwap,
+    DLLSwapped,
     DLLReset,
+    DLLDetected,
+    DLLChangedExternally,
+    DLLBackupRemoved,
 }
 
 public class GameHistory
@@ -25,6 +24,9 @@ public class GameHistory
 
     [Column("asset_type")]
     public GameAssetType? AssetType { get; set; }
+
+    [Column("asset_path")]
+    public string? AssetPath { get; set; }
 
     [Ignore]
     public string AssetTypeName
@@ -45,6 +47,4 @@ public class GameHistory
 
     [Column("asset_version")]
     public string? AssetVersion { get; set; }
-
-
 }

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -236,11 +236,20 @@
   <data name="GameHistoryControl_VersionHeader" xml:space="preserve">
     <value>Version</value>
   </data>
-  <data name="GameHistoryEventType_DLLReset" xml:space="preserve">
-    <value>DLL Reset</value>
+  <data name="GameHistoryEventType_DLLBackupRemoved" xml:space="preserve">
+    <value>DLL backup removed</value>
   </data>
-  <data name="GameHistoryEventType_DLLSwap" xml:space="preserve">
-    <value>DLL Swap</value>
+  <data name="GameHistoryEventType_DLLChangedExternally" xml:space="preserve">
+    <value>DLL was changed externally</value>
+  </data>
+  <data name="GameHistoryEventType_DLLDetected" xml:space="preserve">
+    <value>DLL detected</value>
+  </data>
+  <data name="GameHistoryEventType_DLLReset" xml:space="preserve">
+    <value>DLL reset</value>
+  </data>
+  <data name="GameHistoryEventType_DLLSwapped" xml:space="preserve">
+    <value>DLL swapped</value>
   </data>
   <data name="GameLibrary_UnknownGameLibraryTemplate" xml:space="preserve">
     <value>Could not load game library {0}</value>


### PR DESCRIPTION
## Description of Changes

When a DLL changes externally we delete the backup file. The intent is that when a game updates the backup is removed because the DLL is technically no longer swapped. This leads the user to believe that resetting will put the game back to where it was, but in reality you are swapping back to what the game had before the update.


<!-- Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments. -->

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Issues Resolved

#514

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
