### PR TITLE
Add German (Germany) translation

### DIFF
--- a/src/Helpers/LanguageManager.cs
+++ b/src/Helpers/LanguageManager.cs
@@ -42,6 +42,7 @@ public class LanguageManager
     {
         // For now this is a hardcoded list. It would be nice to dynamically discover from resource class or something.
         return [
+            "de-DE",
             "en-AU",
             "en-GB",
             "en-US",
@@ -62,6 +63,7 @@ public class LanguageManager
         // For now this is a hardcoded list. It would be nice to dynamically discover from resource class or something.
         return languageKey switch
         {
+            "de-DE" => "Deutsch (Deutschland)", // German (Germany)
             "en-AU" => "English (Australia)",
             "en-GB" => "English (United Kingdom)",
             "en-US" => "English (United States)",

--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -1,0 +1,1001 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AcknowledgementsPage_Title" xml:space="preserve">
+    <value>Lizenzen &amp; Danksagungen</value>
+  </data>
+  <data name="ApplicationTitle" xml:space="preserve">
+    <value>DLSS Swapper</value>
+  </data>
+  <data name="DiagnosticsPage_ClickToCopyDetails" xml:space="preserve">
+    <value>Klicken, um die Details zu kopieren</value>
+  </data>
+  <data name="DiagnosticsPage_WindowTitle" xml:space="preserve">
+    <value>Fehlerdiagnose</value>
+  </data>
+  <data name="DllManager_AlreadyImported" xml:space="preserve">
+    <value>(bereits importiert)</value>
+  </data>
+  <data name="DllManager_CouldNotDeserializeManifestException" xml:space="preserve">
+    <value>Die Datei „manifest.json“ konnte nicht deserialisiert werden.</value>
+  </data>
+  <data name="DllManager_ImportFeatureDisabled" xml:space="preserve">
+    <value>Die Importfunktion ist deaktiviert, das Import-Manifest konnte nicht geladen werden.</value>
+  </data>
+  <data name="DllManager_MigratingDlls" xml:space="preserve">
+    <value>Migriere DLLs</value>
+  </data>
+  <data name="DllManager_UnknownTypeDll" xml:space="preserve">
+    <value>Die DLL ist kein bekannter Typ.</value>
+  </data>
+  <data name="DllManager_UntrustedDll" xml:space="preserve">
+    <value>Der DLL wird nicht von Windows vertraut.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
+    <value>Die {0} DLL konnte nicht heruntergeladen werden. Bitte versuche es später noch einmal oder schau in der Log Datei nach, warum der Download nicht geklappt hat.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadFile" xml:space="preserve">
+    <value>Datei konnte nicht heruntergeladen werden.</value>
+  </data>
+  <data name="DllRecord_Download" xml:space="preserve">
+    <value>Herunterladen</value>
+  </data>
+  <data name="DllRecord_DownloadError" xml:space="preserve">
+    <value>Fehler beim herunterladen</value>
+  </data>
+  <data name="DllRecord_DownloadFileWasInvalid" xml:space="preserve">
+    <value>Die heruntergeladene Datei ist fehlerhaft.</value>
+  </data>
+  <data name="DllRecord_Downloading" xml:space="preserve">
+    <value>Lädt herunter</value>
+  </data>
+  <data name="DllRecord_Imported" xml:space="preserve">
+    <value>Importiert</value>
+  </data>
+  <data name="DllRecord_RequiresDownload" xml:space="preserve">
+    <value>Erfordert Download</value>
+  </data>
+  <data name="DllZipInvalidNoDllFound" xml:space="preserve">
+    <value>Die DLL Zip Datei ist fehlerhaft (keine DLL gefunden).</value>
+  </data>
+  <data name="FailedToLaunchPage_DlssSwapperFailedToLaunch" xml:space="preserve">
+    <value>DLSS Swapper konnte nicht gestartet werden.</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial1" xml:space="preserve">
+    <value>Bitte öffne ein</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial2" xml:space="preserve">
+    <value>neues Issue</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial3" xml:space="preserve">
+    <value>im DLSS Swapper GitHub Repository und kopiere die nachfolgenden Informationen in die Sektion "Additional Context".</value>
+  </data>
+  <data name="FailedToLaunchPage_WindowTitle" xml:space="preserve">
+    <value>Konnte nicht gestartet werden</value>
+  </data>
+  <data name="GameHistoryControl_AssetTypeHeader" xml:space="preserve">
+    <value>Asset Typ</value>
+  </data>
+  <data name="GameHistoryControl_EventTimeHeader" xml:space="preserve">
+    <value>Event Zeit</value>
+  </data>
+  <data name="GameHistoryControl_EventTypeHeader" xml:space="preserve">
+    <value>Event Typ</value>
+  </data>
+  <data name="GameHistoryControl_NoHistoryLabel" xml:space="preserve">
+    <value>Keine Historie gefunden.</value>
+  </data>
+  <data name="GameHistoryControl_VersionHeader" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="GameHistoryEventType_DLLBackupRemoved" xml:space="preserve">
+    <value>DLL Backup entfernt</value>
+  </data>
+  <data name="GameHistoryEventType_DLLChangedExternally" xml:space="preserve">
+    <value>DLL wurde extern verändert</value>
+  </data>
+  <data name="GameHistoryEventType_DLLDetected" xml:space="preserve">
+    <value>DLL erkannt</value>
+  </data>
+  <data name="GameHistoryEventType_DLLReset" xml:space="preserve">
+    <value>DLL zurückgesetzt</value>
+  </data>
+  <data name="GameHistoryEventType_DLLSwapped" xml:space="preserve">
+    <value>DLL ausgetauscht</value>
+  </data>
+  <data name="GameLibrary_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>Spiele Bibliothek von {0} konnte nicht geladen werden</value>
+  </data>
+  <data name="GamePage_AddCustomCover" xml:space="preserve">
+    <value>Eigenes Titelbild hinzufügen</value>
+  </data>
+  <data name="GamePage_ClickToFavorite" xml:space="preserve">
+    <value>Zu Favoriten hinzufügen</value>
+  </data>
+  <data name="GamePage_CouldNotFindGameInstallPathTemplate" xml:space="preserve">
+    <value>Der Pfad "{0}" konnte nicht gefunden werden.</value>
+  </data>
+  <data name="GamePage_CurrentDll" xml:space="preserve">
+    <value>Aktuelle DLL</value>
+  </data>
+  <data name="GamePage_DllPicker_CouldNotFindFileTemplate" xml:space="preserve">
+    <value>Die Datei "{0}" konnte nicht gefunden werden.</value>
+  </data>
+  <data name="GamePage_DllPicker_ResetDllToVersionTemplate" xml:space="preserve">
+    <value>Die DLL wurde auf Version {0} zurückgesetzt.</value>
+  </data>
+  <data name="GamePage_DllPicker_StartingDownload" xml:space="preserve">
+    <value>Starte Download</value>
+  </data>
+  <data name="GamePage_DllPicker_WaitToDownloadBeforeSwapping" xml:space="preserve">
+    <value>Bitte warte bis der Download abgeschlossen ist bevor Du die Datei tauschst</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo" xml:space="preserve">
+    <value>Preset Informationen</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Message" xml:space="preserve">
+    <value>Die DLSS Presets sind innerhalb der DLSS-DLL Dateien, die in deinem Spiel-Verzeichnis liegen, eingebettet. Verschiedene DLLs können verschiedene Presets beinhalten. Beispielsweise existierte das Preset K nicht vor der DLSS Version v310.2. Wenn Du also die DLSS Version v3.7 benutzt und das Preset K setzt, dann wird es nicht genutzt sondern das Spiel fällt auf das jeweilige Standard Preset zurück.
+
+Das ganze passiert auch bei den Globalen Presets. Wenn Du Preset K auswählst, dein Spiel jedoch DLSS Version v3.7 benutzt, wird nicht das Preset K verwendet sondern das Standard Preset des Spiels.
+
+Um zu überprüfen welches Preset gerade benutzt wird, aktiviere den DLSS On-Screen Indikator.</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_OnScreenIndicator" xml:space="preserve">
+    <value>On-Screen Indikator Informationen</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Title" xml:space="preserve">
+    <value>DLSS Preset Informationen</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Tooltip" xml:space="preserve">
+    <value>Ein DLSS Preset zu setzen, garantiert nicht das es auch benutzt wird.</value>
+  </data>
+  <data name="GamePage_Favorited" xml:space="preserve">
+    <value>Favorisiert</value>
+  </data>
+  <data name="GamePage_History" xml:space="preserve">
+    <value>Historie</value>
+  </data>
+  <data name="GamePage_InstallPath" xml:space="preserve">
+    <value>Installationspfad</value>
+  </data>
+  <data name="GamePage_InvalidFileTypeTemplate" xml:space="preserve">
+    <value>"{0}" ist ein ungültiger Datei-Typ</value>
+  </data>
+  <data name="GamePage_Launch" xml:space="preserve">
+    <value>Starten</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_CantBeRemoved" xml:space="preserve">
+    <value>Dieses Spiel ist nicht manuell hinzufügt, kann also nicht entfernt werden.</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_RemoveGameTemplate" xml:space="preserve">
+    <value>Bist Du dir sicher dass Du "{0}" aus DLSS Swapper entfernen willst? Hiermit werden keine Änderungen an den DLSS Dateien vorgenommen die bereits getauscht wurden.</value>
+  </data>
+  <data name="GamePage_MultipleDllFound_Notice" xml:space="preserve">
+    <value>Unten siehst Du die gefundenen DLLs. Du kannst weiterhin DLLs austauschen und zurücksetzen wie zuvor, jedoch werden die Aktionen für alle gefunden DLLs ausgeführt. Da wir jedoch nicht wissen welcher dieser DLLs von dem Titel verwendet werden, wird nur die Version der ersten gefunden DLL angezeigt.</value>
+  </data>
+  <data name="GamePage_MultipleDllsFound" xml:space="preserve">
+    <value>Mehrere DLLs gefunden</value>
+  </data>
+  <data name="GamePage_MultipleDllsFoundTemplate" xml:space="preserve">
+    <value>Mehrere {0} DLLs gefunden</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Message" xml:space="preserve">
+    <value>Bitte wechsle zur Seite der Bibliothek um neue DLLs herunterzuladen.</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Title" xml:space="preserve">
+    <value>Keine DLLs gefunden.</value>
+  </data>
+  <data name="GamePage_Notes" xml:space="preserve">
+    <value>Notizen</value>
+  </data>
+  <data name="GamePage_NotReadyToPlayState" xml:space="preserve">
+    <value>Dieses Spiel befindet sich noch nicht in einem spielbaren Zustand.</value>
+  </data>
+  <data name="GamePage_OpenDllLocation" xml:space="preserve">
+    <value>Öffne DLL Lokation</value>
+  </data>
+  <data name="GamePage_OriginalDll" xml:space="preserve">
+    <value>Originale DLL</value>
+  </data>
+  <data name="GamePage_ProcessingPleaseWaitTemplate" xml:space="preserve">
+    <value>{0} wird immer noch untersucht. Bitte warte bis der Lade-Indikator vollendet ist bevor Du es öffnest.</value>
+  </data>
+  <data name="GamePage_RestoreOriginalDll" xml:space="preserve">
+    <value>Originale DLL wiederherstellen</value>
+  </data>
+  <data name="GamePage_SelectDllTemplateTitle" xml:space="preserve">
+    <value>Wähle {0} Version</value>
+  </data>
+  <data name="GamePage_StorageFileIsNull" xml:space="preserve">
+    <value>storageFile ist NULL</value>
+  </data>
+  <data name="GamePage_UnableToChangePreset" xml:space="preserve">
+    <value>Preset konnte nicht geändert werden. Weitere Infos findest Du in der Log-Datei.</value>
+  </data>
+  <data name="GamePage_YouMayOnlyDragOneFileCover" xml:space="preserve">
+    <value>Du kannst nur eine einzige Datei als Titelbild auswählen.</value>
+  </data>
+  <data name="GamesPage_AddGame" xml:space="preserve">
+    <value>Spiel hinzufügen</value>
+  </data>
+  <data name="GamesPage_GroupGamesFromTheSameLibraryTogether" xml:space="preserve">
+    <value>Gruppiere Spiele der gleichen Bibliothek</value>
+  </data>
+  <data name="GamesPage_Grouping" xml:space="preserve">
+    <value>Gruppierung</value>
+  </data>
+  <data name="GamesPage_HideGamesWithNoSwappableItems" xml:space="preserve">
+    <value>Verstecke Spiele deren Dateien nicht getauscht werden können</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AddCoverErrorSingleFile" xml:space="preserve">
+    <value>Du kannst nur eine einzige Datei als Titelbild auswählen.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AnotherNoteTitle" xml:space="preserve">
+    <value>Eine weitere Notiz für manuell hinzufügte Spiele</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_CouldntAddError" xml:space="preserve">
+    <value>Es ist ein Problem aufgetreten und das Spiel konnte nicht hinzugefügt werden. Bitte melde diesen Fehler.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_ErrorTitle" xml:space="preserve">
+    <value>Fehler beim hinzufügen des Spiels</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_InfoHtml" xml:space="preserve">
+    <value>Du musst dein &lt;i&gt;Spiel&lt;/i&gt; Verzeichnis und nicht dein &lt;i&gt;Spiele&lt;/i&gt; Verzeichnis auswählen.&lt;br/&gt;&lt;br/&gt;Als Beispiel: Wenn dein Spiel in diesem Verzeichnis installiert ist:&lt;br/&gt;&lt;b&gt;C:\Programme\MeinSpieleOrdner\MeinLieblingsSpiel\&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Dann wählst Du das Verzeichnis &lt;b&gt;MeinLieblingsSpiel&lt;/b&gt; und nicht &lt;b&gt;MeinSpieleOrdner&lt;/b&gt; aus.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteMessage" xml:space="preserve">
+    <value>DLSS Swapper sollte Spiele von deinen installierten Spiele Bibliotheken automatisch erkennen. Wenn dein Spiel jedoch nicht aufgelistet sein sollte, können möglicherweise einige Einstellungen daran Schuld sein. Bitte prüfe:
+
+- Das die Option "Verstecke Spiele deren Dateien nicht getauscht werden können" nicht gesetzt ist
+- Das die Spiele Bibliothek auch in den Einstellungen aktiviert ist
+
+Wenn Du alles überprüft hast und dein Spiel taucht immer noch nicht auf, liegt möglicherweise ein Fehler vor. Wir würden es begrüßen wenn Du diesen Fehler im GitHub Repository meldest, damit wir diesen Fehler beheben und deine Spiele in Zukunft besser erkennen können.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteTitle" xml:space="preserve">
+    <value>Anmerkung für manuell hinzugefügte Spiele</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_PathExistsTemplate" xml:space="preserve">
+    <value>Der Installationspfad "{0}" existiert bereits und kann nicht noch einmal hinzugefügt werden.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_SelectGameFolder" xml:space="preserve">
+    <value>Wähle Spiel Ordner aus</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_TopLevelDirectoryNotSupported" xml:space="preserve">
+    <value>Das hinzufügen des obersten Verzeichnisses ist nicht unterstützt. Bitte wähle das Stammverzeichnis deines Spiels aus.</value>
+  </data>
+  <data name="GamesPage_NewDlls" xml:space="preserve">
+    <value>Neue DLLs</value>
+  </data>
+  <data name="GamesPage_NewDllsFound" xml:space="preserve">
+    <value>Neue DLLs gefunden</value>
+  </data>
+  <data name="GamesPage_NewDlls_CreateNewGitHubIssue" xml:space="preserve">
+    <value>Ein neues GitHub Issue erstellen</value>
+  </data>
+  <data name="GamesPage_NewDlls_DiscoveredHelpUs" xml:space="preserve">
+    <value>Während dein Spiel geladen wurde haben wir neue DLLs gefunden, die nicht im DLSS Swapper Manifest vorhanden sind.</value>
+  </data>
+  <data name="GamesPage_NewDlls_GitHubAccountRequired" xml:space="preserve">
+    <value>(GitHub Account erforderlich)</value>
+  </data>
+  <data name="GamesPage_NewDlls_IfButtonDoesntWorkTryHere" xml:space="preserve">
+    <value>Wenn der Button nicht funktioniert, versuche das:</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepFourSubmitYourIssue" xml:space="preserve">
+    <value>Schritt 4: Öffne dein Issue</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepOneCreateNewIssue" xml:space="preserve">
+    <value>Schritt 1: Erstelle ein neues Issue</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepThreeCopyBody" xml:space="preserve">
+    <value>Schritt 3: Kopiere den Text</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepTwoCopyTitle" xml:space="preserve">
+    <value>Schritt 2: Kopiere den Titel</value>
+  </data>
+  <data name="GamesPage_NewDlls_ThanksForHelping" xml:space="preserve">
+    <value>Danke für deine Hilfe!</value>
+  </data>
+  <data name="GamesPage_NewDlls_YouDoNotHaveToSubmitDllAutoTrack" xml:space="preserve">
+    <value>Du musst keine DLLs mit mitschicken. Wir finden sie anhand der hinzugefügten Informationen.</value>
+  </data>
+  <data name="GamesPage_Title" xml:space="preserve">
+    <value>Spiele</value>
+  </data>
+  <data name="GamesPage_ViewType" xml:space="preserve">
+    <value>Ansichtsart</value>
+  </data>
+  <data name="GamesPage_ViewType_GridView" xml:space="preserve">
+    <value>Gitteransicht</value>
+  </data>
+  <data name="GamesPage_ViewType_ListView" xml:space="preserve">
+    <value>Listenansicht</value>
+  </data>
+  <data name="Game_AreYouSureRemoveCustomCover" xml:space="preserve">
+    <value>Bist Du dir sicher, dass Du dein hinzugefügtes Titelbild entfernen willst?</value>
+  </data>
+  <data name="Game_CurrentlyProcessing" xml:space="preserve">
+    <value>Spiel wird aktuell untersucht</value>
+  </data>
+  <data name="Game_CustomCoverRemove" xml:space="preserve">
+    <value>Titelbild entfernen?</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeCatalog" xml:space="preserve">
+    <value>Konnte die GOGCatalogResponse für die folgende URL {0} nicht deserialisieren</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeEmbedFilterResponse" xml:space="preserve">
+    <value>Konnte die GOGEmbedFilteredResponse für die folgende URL {0} nicht deserialisieren</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyEmbedFilteredProducts" xml:space="preserve">
+    <value>Konnte keine GOGEmbedFilteredProducts für die folgende URL {0} finden</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyProduct" xml:space="preserve">
+    <value>Konnte kein GOGCatalogProduct für die folgende URL {0} finden</value>
+  </data>
+  <data name="Game_UbisoftConnect_CouldNotDetectInstallKey" xml:space="preserve">
+    <value>Konnte den ubisoftConnectInstallsKey nicht finden</value>
+  </data>
+  <data name="Game_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>Unbekannte GameLibrary {0} beim festlegen der ID</value>
+  </data>
+  <data name="General_ApplicationRunningAsAdmin" xml:space="preserve">
+    <value>Diese App läuft mit Administrativen Benutzerrechten.</value>
+  </data>
+  <data name="General_Apply" xml:space="preserve">
+    <value>Anwenden</value>
+  </data>
+  <data name="General_Cancel" xml:space="preserve">
+    <value>Abbrechen</value>
+  </data>
+  <data name="General_Close" xml:space="preserve">
+    <value>Schließen</value>
+  </data>
+  <data name="General_Copy" xml:space="preserve">
+    <value>Kopieren</value>
+  </data>
+  <data name="General_Delete" xml:space="preserve">
+    <value>Löschen</value>
+  </data>
+  <data name="General_DontShowAgain" xml:space="preserve">
+    <value>Nicht mehr anzeigen</value>
+  </data>
+  <data name="General_Error" xml:space="preserve">
+    <value>Fehler</value>
+  </data>
+  <data name="General_ErrorMessage" xml:space="preserve">
+    <value>Fehlerbeschreibung</value>
+  </data>
+  <data name="General_Export" xml:space="preserve">
+    <value>Exportieren</value>
+  </data>
+  <data name="General_ExportAll" xml:space="preserve">
+    <value>Alle exportieren</value>
+  </data>
+  <data name="General_Failed" xml:space="preserve">
+    <value>Fehlgeschlagen</value>
+  </data>
+  <data name="General_FeatureNotSupportedWhenAdmin" xml:space="preserve">
+    <value>Dieses Feature wird nicht unterstützt während die App mit Administrativen Benutzerrechten ausgeführt wird.</value>
+  </data>
+  <data name="General_Filter" xml:space="preserve">
+    <value>Filter</value>
+  </data>
+  <data name="General_Help" xml:space="preserve">
+    <value>Hilfe</value>
+  </data>
+  <data name="General_Import" xml:space="preserve">
+    <value>Importieren</value>
+  </data>
+  <data name="General_Load" xml:space="preserve">
+    <value>Laden</value>
+  </data>
+  <data name="General_Loading" xml:space="preserve">
+    <value>Lade</value>
+  </data>
+  <data name="General_Name" xml:space="preserve">
+    <value>Name</value>
+  </data>
+  <data name="General_No" xml:space="preserve">
+    <value>Nein</value>
+  </data>
+  <data name="General_None" xml:space="preserve">
+    <value>Keine</value>
+  </data>
+  <data name="General_NotSupported" xml:space="preserve">
+    <value>Nicht unterstützt</value>
+  </data>
+  <data name="General_Okay" xml:space="preserve">
+    <value>Okay</value>
+  </data>
+  <data name="General_Oops" xml:space="preserve">
+    <value>Ups</value>
+  </data>
+  <data name="General_OpenFolder" xml:space="preserve">
+    <value>Öffne Verzeichnis</value>
+  </data>
+  <data name="General_Optional" xml:space="preserve">
+    <value>(optional)</value>
+  </data>
+  <data name="General_Options" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="General_Publish" xml:space="preserve">
+    <value>Veröffentlichen</value>
+  </data>
+  <data name="General_Refresh" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="General_Reload" xml:space="preserve">
+    <value>Neu laden</value>
+  </data>
+  <data name="General_Remove" xml:space="preserve">
+    <value>Entfernen</value>
+  </data>
+  <data name="General_ReportIssue" xml:space="preserve">
+    <value>Fehler melden</value>
+  </data>
+  <data name="General_Save" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="General_Search" xml:space="preserve">
+    <value>Suchen</value>
+  </data>
+  <data name="General_Sorry" xml:space="preserve">
+    <value>Entschuldige</value>
+  </data>
+  <data name="General_Success" xml:space="preserve">
+    <value>Erfolg</value>
+  </data>
+  <data name="General_Swap" xml:space="preserve">
+    <value>Tauschen</value>
+  </data>
+  <data name="General_Unknown" xml:space="preserve">
+    <value>Unbekannt</value>
+  </data>
+  <data name="General_Update" xml:space="preserve">
+    <value>Aktualisieren</value>
+  </data>
+  <data name="General_Version" xml:space="preserve">
+    <value>Version</value>
+  </data>
+  <data name="General_Warning" xml:space="preserve">
+    <value>Warnung</value>
+  </data>
+  <data name="General_Yes" xml:space="preserve">
+    <value>Ja</value>
+  </data>
+  <data name="GitHubUpdater_CouldNotLoadGitHubReleaseDataException" xml:space="preserve">
+    <value>Die GitHub-Release-Daten konnten nicht geladen werden.</value>
+  </data>
+  <data name="GitHubUpdater_CurrentVersionIsActualTemplate" xml:space="preserve">
+    <value>Aktuell ist die Version {0} installiert.</value>
+  </data>
+  <data name="GitHubUpdater_DlssSwapperUpdated" xml:space="preserve">
+    <value>DLSS Swapper wurde gerade aktualisiert</value>
+  </data>
+  <data name="GitHubUpdater_UpdateAvailable" xml:space="preserve">
+    <value>Update Verfügbar</value>
+  </data>
+  <data name="LibraryPage_AlreadyDownloaded" xml:space="preserve">
+    <value>Bereits heruntergeladen.</value>
+  </data>
+  <data name="LibraryPage_CouldNotLoadImportedDlls" xml:space="preserve">
+    <value>Die importierten DLLs konnten nicht geladen werden</value>
+  </data>
+  <data name="LibraryPage_CouldntDownload" xml:space="preserve">
+    <value>Kann gerade nicht heruntergeladen werden.</value>
+  </data>
+  <data name="LibraryPage_CouldntExportDll" xml:space="preserve">
+    <value>Die DLLs konnten nicht exportiert werden.</value>
+  </data>
+  <data name="LibraryPage_DeleteDll" xml:space="preserve">
+    <value>Lösche DLL</value>
+  </data>
+  <data name="LibraryPage_DeleteDllVersionTemplate" xml:space="preserve">
+    <value>DLL {0} v{1} löschen?</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_DownloadFileSize" xml:space="preserve">
+    <value>Downloadgröße</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileDescription" xml:space="preserve">
+    <value>Dateibeschreibung</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileSize" xml:space="preserve">
+    <value>Dateigröße</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalName" xml:space="preserve">
+    <value>Interner Name</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalNameExtra" xml:space="preserve">
+    <value>Interner Name Extra</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Label" xml:space="preserve">
+    <value>Stichwort</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Message" xml:space="preserve">
+    <value>{0} neue Downloads gestartet.</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Title" xml:space="preserve">
+    <value>Downloads gestartet</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLs" xml:space="preserve">
+    <value>Exportierte DLLs:</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLsCount_Message" xml:space="preserve">
+    <value>{0} DLLs wurden exportiert.</value>
+  </data>
+  <data name="LibraryPage_ExportedDllTemplate" xml:space="preserve">
+    <value>DLL {0} wurde exportiert.</value>
+  </data>
+  <data name="LibraryPage_FileNotFound" xml:space="preserve">
+    <value>Datei nicht gefunden</value>
+  </data>
+  <data name="LibraryPage_Finished" xml:space="preserve">
+    <value>Abgeschlossen</value>
+  </data>
+  <data name="LibraryPage_ImportedAsExistingRecord" xml:space="preserve">
+    <value>Als vorhandener DLL Eintrag importiert.</value>
+  </data>
+  <data name="LibraryPage_Importing" xml:space="preserve">
+    <value>Importiere</value>
+  </data>
+  <data name="LibraryPage_MaliciousDllsInfo" xml:space="preserve">
+    <value>Das ersetzen von DLL Dateien auf deinem Computer kann gefährlich sein.
+
+Das einfügen einer bösartigen DLL-Datei in ein Spiel ist genauso schlimm wie das Ausführen der Datei "Linking_park_-_nUmB_mp3.exe", welche Du gerade von LimeWire heruntergeladen hast.
+
+Importiere DLL-Dateien nur aus einer vertrauenswürdigen Quelle!</value>
+  </data>
+  <data name="LibraryPage_NoDLLsForExport_Message" xml:space="preserve">
+    <value>Keine DLLs zum exportieren gefunden.</value>
+  </data>
+  <data name="LibraryPage_NoDllsToExport" xml:space="preserve">
+    <value>Du hast keine DLL-Einträge zum exportieren.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Message" xml:space="preserve">
+    <value>Es wurden keine neuen DLLs heruntergeladen.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Title" xml:space="preserve">
+    <value>Keine neuen DLLs</value>
+  </data>
+  <data name="LibraryPage_ProcessedDlls" xml:space="preserve">
+    <value>Verarbeitete DLLs:</value>
+  </data>
+  <data name="LibraryPage_Title" xml:space="preserve">
+    <value>Bibliothek</value>
+  </data>
+  <data name="LibraryPage_UnableToDeleteRecord" xml:space="preserve">
+    <value>Konnte Eintrag {0} nicht löschen</value>
+  </data>
+  <data name="LibraryPage_UnableToUpdateDllRecord" xml:space="preserve">
+    <value>Konnte die DLL-Einträge nicht aktualisieren</value>
+  </data>
+  <data name="LibraryPage_ZipDidNotContainAnyDlls" xml:space="preserve">
+    <value>Die .zip Datei beinhaltete keine neuen DLLs.</value>
+  </data>
+  <data name="MainWindow_AttemptingManifestUpdate" xml:space="preserve">
+    <value>Versuche zu aktualisieren</value>
+  </data>
+  <data name="MainWindow_DlssSwapperCloseDueToManifest" xml:space="preserve">
+    <value>DLSS Swapper konnte die Manifest-Datei nicht laden. Die App wird jetzt geschlossen.</value>
+  </data>
+  <data name="MainWindow_DlssSwapperMustClose" xml:space="preserve">
+    <value>DLSS Swapper muss geschlossen werden</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_GitHubIssues" xml:space="preserve">
+    <value>GitHub Issues</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_Message" xml:space="preserve">
+    <value>Wir konnten die manifest.json weder von deinem Computer noch aus dem Internet laden.
+
+Sollte dieses Problem weiterbestehen bitte melde dieses Problem in unserem GitHub Issue Tracker.</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_UpdateManifest" xml:space="preserve">
+    <value>Manifest aktualisieren</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Message" xml:space="preserve">
+    <value>DLSS Dateien austauschen sollte nicht als cheaten gewertet werden, manche Anti-Cheat-Systeme könnten aber nicht glücklich darüber sein, dass Du mit den Spiel-Dateien im Verzeichnis herumhantierst. Sie erwarten die Original Dateien vorzufinden.
+
+Aus diesem Umstand empfehlen wir besondere Vorsicht im Umgang mit Multiplayer Spielen.</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Title" xml:space="preserve">
+    <value>Anmerkung für Multiplayer Spiele</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterStillDoesNotWork" xml:space="preserve">
+    <value>Funktioniert immer noch nicht</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterWorks" xml:space="preserve">
+    <value>Funktioniert!</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTestTitle" xml:space="preserve">
+    <value>Browser Test</value>
+  </data>
+  <data name="NetworkTesterPage_CancelCurrentTest" xml:space="preserve">
+    <value>Aktuellen Test abbrechen</value>
+  </data>
+  <data name="NetworkTesterPage_CopyTestResults" xml:space="preserve">
+    <value>Testergebnisse kopieren</value>
+  </data>
+  <data name="NetworkTesterPage_CreateBugReport" xml:space="preserve">
+    <value>Fehlermeldung erstellen</value>
+  </data>
+  <data name="NetworkTesterPage_CustomUserAgentTest" xml:space="preserve">
+    <value>Benutzerdefinierter User-Agent Test</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest10Title" xml:space="preserve">
+    <value>Downloade DLSS Swapper DLL innerhalb von DLSS Swapper mit benutzerdefiniertem User-Agent</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest11Title" xml:space="preserve">
+    <value>Downloade DLSS DLL von UploadThing Server</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest1Title" xml:space="preserve">
+    <value>Versuche eine Verbindung zu google.com von innerhalb DLSS Swapper aufzubauen (Testet die generelle Verbindung zum Internet)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest2Title" xml:space="preserve">
+    <value>Versuche eine Verbindung zu bing.com von innerhalb DLSS Swapper aufzubauen (Testet die generelle Verbindung zum Internet)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest3Title" xml:space="preserve">
+    <value>Downloade DLSS Swapper DLL innerhalb von DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest4Title" xml:space="preserve">
+    <value>Downloade DLSS Swapper DLL aus dem Browser heraus</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest5Title" xml:space="preserve">
+    <value>Lade Spiel-Titelbild von Steam herunter</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest6Title" xml:space="preserve">
+    <value>Lade Spiel-Titelbild aus dem Epic Games Store herunter</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest7Title" xml:space="preserve">
+    <value>Lade Spiel-Titelbild vom DLSS Swapper Dateiserver herunter</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest8Title" xml:space="preserve">
+    <value>Lade Spiel-Titelbild vom alternativen DLSS Swapper Dateiserver herunter</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest9Title" xml:space="preserve">
+    <value>DNS-Abfrage für den DLSS Swapper Dateiserver</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowser" xml:space="preserve">
+    <value>Im Browser öffnen</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowserInfo" xml:space="preserve">
+    <value>Klicke auf den "Im Browser öffnen" Button oder kopiere und füge die folgende URL in deinem Browser ein. Wird danach eine Datei aus deinem Browser heruntergeladen?</value>
+  </data>
+  <data name="NetworkTesterPage_Results" xml:space="preserve">
+    <value>Ergebnisse</value>
+  </data>
+  <data name="NetworkTesterPage_RunTest" xml:space="preserve">
+    <value>Test starten</value>
+  </data>
+  <data name="NetworkTesterPage_UseUserAgentInfo" xml:space="preserve">
+    <value>Verwende den vorgegebenen User-Agent oder füge einen eigenen deiner Wahl ein.</value>
+  </data>
+  <data name="NetworkTesterPage_WindowTitle" xml:space="preserve">
+    <value>Netzwerk Tester</value>
+  </data>
+  <data name="SettingsPage_About" xml:space="preserve">
+    <value>Über</value>
+  </data>
+  <data name="SettingsPage_AddIgnoredPath" xml:space="preserve">
+    <value>Ignorierten Pfad hinzufügen</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDlls" xml:space="preserve">
+    <value>Erlaube Debug DLLs</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDllsInfo" xml:space="preserve">
+    <value>Die SDKs erhalten manchmal Debug DLLs welche zusätzliche On-Screen Informationen auf deinem Bildschirm während des spielens anzeigen.</value>
+  </data>
+  <data name="SettingsPage_AllowUntrustedInfo" xml:space="preserve">
+    <value>DLLs werden in Windows auf Vertrauenswürdigkeit geprüft, indem ihre Signatur überprüft wird bevor sie in ein Spiele-Verzeichnis kopiert werden. Wenn eine DLL die Signaturprüfung nicht besteht, wird sie nicht verwendet. Es wird empfohlen, diese Option deaktiviert zu lassen.</value>
+  </data>
+  <data name="SettingsPage_AppliesOnlyToDllPickerNotLibrary" xml:space="preserve">
+    <value>Diese Option gilt nur für den DLL Picker, nicht für die Bibliotheksseite.</value>
+  </data>
+  <data name="SettingsPage_CouldNotOpenLogFileTryManual" xml:space="preserve">
+    <value>Konnte das Log-Verzeichnis nicht aus DLSS Swapper heraus öffnen. Bitte versuche es manuell zu öffnen.</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathMessage" xml:space="preserve">
+    <value>Bist Du dir sicher, dass Du den ignorierten Pfad {0} löschen willst?</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathTitle" xml:space="preserve">
+    <value>Lösche ignorierten Pfad</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions" xml:space="preserve">
+    <value>DLSS Entwickler Optionen</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToConsoleWindow" xml:space="preserve">
+    <value>Aktiviere Logging in ein Konsolenfenster</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToFile" xml:space="preserve">
+    <value>Aktiviere Logging in eine Datei</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForAllDlssDlls" xml:space="preserve">
+    <value>Für alle DLSS DLLs</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForDebugDlssDllOnly" xml:space="preserve">
+    <value>Nur für DLSS Debug DLLs</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_ShowOnScreenIndicator" xml:space="preserve">
+    <value>On-Screen Indikator anzeigen</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_VerboseLogging" xml:space="preserve">
+    <value>Ausführliches Logging</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions" xml:space="preserve">
+    <value>DLSS Optionen</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions_GlobalPreset" xml:space="preserve">
+    <value>Globales Preset</value>
+  </data>
+  <data name="SettingsPage_GameLibraries" xml:space="preserve">
+    <value>Spiel Bibliotheken</value>
+  </data>
+  <data name="SettingsPage_GeneralTroubleshootingGuide" xml:space="preserve">
+    <value>Allgemeine Fehlerbehebung</value>
+  </data>
+  <data name="SettingsPage_GiveFeedback" xml:space="preserve">
+    <value>Feedback geben</value>
+  </data>
+  <data name="SettingsPage_GiveFeedbackInfo" xml:space="preserve">
+    <value>Du kannst eine Funktion vorschlagen oder ein Problem melden.</value>
+  </data>
+  <data name="SettingsPage_IgnoredPaths" xml:space="preserve">
+    <value>Ignorierte Pfade</value>
+  </data>
+  <data name="SettingsPage_Language" xml:space="preserve">
+    <value>Sprache</value>
+  </data>
+  <data name="SettingsPage_LibraryDisabled" xml:space="preserve">
+    <value>{0} deaktiviert</value>
+  </data>
+  <data name="SettingsPage_LibraryEnabled" xml:space="preserve">
+    <value>{0} aktiviert</value>
+  </data>
+  <data name="SettingsPage_Logging" xml:space="preserve">
+    <value>Logging</value>
+  </data>
+  <data name="SettingsPage_NoNewUpdatesAvailable" xml:space="preserve">
+    <value>Keine neuen Updates verfügbar.</value>
+  </data>
+  <data name="SettingsPage_OpenAcknowledgements" xml:space="preserve">
+    <value>Danksagungen</value>
+  </data>
+  <data name="SettingsPage_OpenDiagnostics" xml:space="preserve">
+    <value>Fehlerdiagnose</value>
+  </data>
+  <data name="SettingsPage_OpenNetworkTester" xml:space="preserve">
+    <value>Netzwerk Tester</value>
+  </data>
+  <data name="SettingsPage_OpenTranslationToolbox" xml:space="preserve">
+    <value>Öffne Übersetzungs-Toolbox</value>
+  </data>
+  <data name="SettingsPage_PathAlreadyIgnored" xml:space="preserve">
+    <value>Der Pfad {0} wird bereits ignoriert.</value>
+  </data>
+  <data name="SettingsPage_SettingsAllowUntrusted" xml:space="preserve">
+    <value>Erlaube nicht-vertrauten DLLs</value>
+  </data>
+  <data name="SettingsPage_SettingsCheckForUpdates" xml:space="preserve">
+    <value>Prüfe auf Updates</value>
+  </data>
+  <data name="SettingsPage_ShowOnlyDownloadedDlls" xml:space="preserve">
+    <value>Zeige nur heruntergeladene DLLs</value>
+  </data>
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
+    <value>Dunkel</value>
+  </data>
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
+    <value>Hell</value>
+  </data>
+  <data name="SettingsPage_ThemeMode" xml:space="preserve">
+    <value>Theme Modus</value>
+  </data>
+  <data name="SettingsPage_ThemeSystemSettingDefault" xml:space="preserve">
+    <value>Systemeinstellung verwenden</value>
+  </data>
+  <data name="SettingsPage_Title" xml:space="preserve">
+    <value>Einstellungen</value>
+  </data>
+  <data name="SettingsPage_Troubleshooting" xml:space="preserve">
+    <value>Fehlerbehebung</value>
+  </data>
+  <data name="SettingsPage_YourCurrentLogFile" xml:space="preserve">
+    <value>Die aktuelle Logdatei befindet sich hier: </value>
+  </data>
+  <data name="TranslationToolboxPage_AdminError" xml:space="preserve">
+    <value>Du kannst das Übersetzungs Tool nicht benutzen während Du die App mit Administrator Benutzerrechten benutzt. Bitte starte die App neu.</value>
+  </data>
+  <data name="TranslationToolboxPage_Comment" xml:space="preserve">
+    <value>Kommentar</value>
+  </data>
+  <data name="TranslationToolboxPage_ImportAsTranslation" xml:space="preserve">
+    <value>Sprache als Übersetzung importieren</value>
+  </data>
+  <data name="TranslationToolboxPage_Key" xml:space="preserve">
+    <value>Schlüssel</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadExistingTranslation" xml:space="preserve">
+    <value>Vorhandene laden</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadFailedMessage" xml:space="preserve">
+    <value>Übersetzung konnte nicht geladen werden. Bitte prüfe die Logdatei für mehr Informationen.</value>
+  </data>
+  <data name="TranslationToolboxPage_NewTranslation" xml:space="preserve">
+    <value>Neue Übersetzung</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToPublish" xml:space="preserve">
+    <value>Es wurden keine Übersetzungsdaten gefunden, die veröffentlicht werden können.</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToSave" xml:space="preserve">
+    <value>Es wurden keine Übersetzungsdaten gefunden, die gespeichert werden konnten.</value>
+  </data>
+  <data name="TranslationToolboxPage_NotValidTranslationFile" xml:space="preserve">
+    <value>Keine gültige DLSS Swapper-Übersetzungsdatei.</value>
+  </data>
+  <data name="TranslationToolboxPage_PublishFailedMessage" xml:space="preserve">
+    <value>Übersetzung konnte nicht veröffentlicht werden. Bitte prüfe die Logdatei für mehr Informationen.</value>
+  </data>
+  <data name="TranslationToolboxPage_ReloadApp" xml:space="preserve">
+    <value>App neuladen</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressButton" xml:space="preserve">
+    <value>Zurücksetzen und fortfahren</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressMessage" xml:space="preserve">
+    <value>Damit wird dein aktueller Übersetzungsfortschritt zurückgesetzt. Willst Du wirklich fortfahren?</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressTitle" xml:space="preserve">
+    <value>Fortschritt zurücksetzen und fortfahren?</value>
+  </data>
+  <data name="TranslationToolboxPage_SaveFailedMessage" xml:space="preserve">
+    <value>Übersetzung konnte nicht gespeichert werden. Bitte prüfe die Logdatei für mehr Informationen.</value>
+  </data>
+  <data name="TranslationToolboxPage_SelectLanguageToLoad" xml:space="preserve">
+    <value>Wähle die zu ladende Sprache aus</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceLanguage" xml:space="preserve">
+    <value>Ausgangssprache</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceTranslation" xml:space="preserve">
+    <value>Ausgangsquelle</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideButton" xml:space="preserve">
+    <value>Übersetzungshilfe</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideMessage" xml:space="preserve">
+    <value>Deine Übersetzung wurde erstellt. Bitte schau in der DLSS Swapper Übersetzungshilfe nach was Du mit der folgenden Datei als nächstes tun sollst: {0}</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationProgress" xml:space="preserve">
+    <value>Übersetzungsfortschritt</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesButton" xml:space="preserve">
+    <value>Ohne speichern schließen</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesMessage" xml:space="preserve">
+    <value>Du hast noch ungespeicherte Übersetzungen. Wenn Du dieses Fenster schließt werden sie verloren gehen.</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesTitle" xml:space="preserve">
+    <value>Ungespeicherte Übersetzungen</value>
+  </data>
+  <data name="TranslationToolboxPage_WindowTitle" xml:space="preserve">
+    <value>Übersetzungs-Toolbox</value>
+  </data>
+</root>

--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -720,10 +720,10 @@ Aus diesem Umstand empfehlen wir besondere Vorsicht im Umgang mit Multiplayer Sp
     <value>Anmerkung für Multiplayer Spiele</value>
   </data>
   <data name="NetworkTesterPage_BrowserTesterStillDoesNotWork" xml:space="preserve">
-    <value>Funktioniert immer noch nicht</value>
+    <value>Funktioniert nicht</value>
   </data>
   <data name="NetworkTesterPage_BrowserTesterWorks" xml:space="preserve">
-    <value>Funktioniert!</value>
+    <value>Funktioniert</value>
   </data>
   <data name="NetworkTesterPage_BrowserTestTitle" xml:space="preserve">
     <value>Browser Test</value>


### PR DESCRIPTION
## Description of Changes

Adds German (Germany) as a selectable translation.

## Type of Change

- [] Bug fix
- [x] New feature
- [] Documentation update

## Issues Resolved

None.

## Additional Information
While skipping through the app to test the translation I found some small spots which aren't translated. Most of them on the detailed game page:
<img width="1010" height="775" alt="image" src="https://github.com/user-attachments/assets/053a5164-eddc-4a86-b922-84f07d719176" />
