### PR TITLE
Adds Catalan (ca-CA) translation

### DIFF
--- a/src/Helpers/LanguageManager.cs
+++ b/src/Helpers/LanguageManager.cs
@@ -42,6 +42,7 @@ public class LanguageManager
     {
         // For now this is a hardcoded list. It would be nice to dynamically discover from resource class or something.
         return [
+            "ca-CA",
             "de-DE",
             "en-AU",
             "en-GB",
@@ -63,6 +64,7 @@ public class LanguageManager
         // For now this is a hardcoded list. It would be nice to dynamically discover from resource class or something.
         return languageKey switch
         {
+            "ca-CA" => "Català", // Catalan
             "de-DE" => "Deutsch (Deutschland)", // German (Germany)
             "en-AU" => "English (Australia)",
             "en-GB" => "English (United Kingdom)",

--- a/src/Translations/ca-CA/Resources.resw
+++ b/src/Translations/ca-CA/Resources.resw
@@ -1,0 +1,1001 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AcknowledgementsPage_Title" xml:space="preserve">
+    <value>Llicències i reconeixements</value>
+  </data>
+  <data name="ApplicationTitle" xml:space="preserve">
+    <value>DLSS Swapper</value>
+  </data>
+  <data name="DiagnosticsPage_ClickToCopyDetails" xml:space="preserve">
+    <value>Clica per copiar els detalls de sota</value>
+  </data>
+  <data name="DiagnosticsPage_WindowTitle" xml:space="preserve">
+    <value>Diagnòstics</value>
+  </data>
+  <data name="DllManager_AlreadyImported" xml:space="preserve">
+    <value>(ja importat)</value>
+  </data>
+  <data name="DllManager_CouldNotDeserializeManifestException" xml:space="preserve">
+    <value>No s'ha pogut deserialitzar manifest.json.</value>
+  </data>
+  <data name="DllManager_ImportFeatureDisabled" xml:space="preserve">
+    <value>La funció d'importació està desactivada; no s'ha pogut carregar el manifest d'importació.</value>
+  </data>
+  <data name="DllManager_MigratingDlls" xml:space="preserve">
+    <value>Migrant DLLs</value>
+  </data>
+  <data name="DllManager_UnknownTypeDll" xml:space="preserve">
+    <value>DLL no és un tipus conegut.</value>
+  </data>
+  <data name="DllManager_UntrustedDll" xml:space="preserve">
+    <value>Windows no confia en la DLL.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
+    <value>No s'ha pogut descarregar la DLL {0}. Si us plau, torneu-ho a provar més tard o consulteu els registres per veure per què ha fallat la descàrrega.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadFile" xml:space="preserve">
+    <value>No s'ha pogut descarregar el fitxer.</value>
+  </data>
+  <data name="DllRecord_Download" xml:space="preserve">
+    <value>Descarregar</value>
+  </data>
+  <data name="DllRecord_DownloadError" xml:space="preserve">
+    <value>Error de descàrrega</value>
+  </data>
+  <data name="DllRecord_DownloadFileWasInvalid" xml:space="preserve">
+    <value>El fitxer descarregat no era vàlid.</value>
+  </data>
+  <data name="DllRecord_Downloading" xml:space="preserve">
+    <value>Descarregant</value>
+  </data>
+  <data name="DllRecord_Imported" xml:space="preserve">
+    <value>Importat</value>
+  </data>
+  <data name="DllRecord_RequiresDownload" xml:space="preserve">
+    <value>Requereix descàrrega</value>
+  </data>
+  <data name="DllZipInvalidNoDllFound" xml:space="preserve">
+    <value>El fitxer zip de la DLL no era vàlid (no s'ha trobat cap DLL).</value>
+  </data>
+  <data name="FailedToLaunchPage_DlssSwapperFailedToLaunch" xml:space="preserve">
+    <value>No s'ha pogut iniciar DLSS Swapper</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial1" xml:space="preserve">
+    <value>Si us plau, obriu un</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial2" xml:space="preserve">
+    <value>nou error</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial3" xml:space="preserve">
+    <value>al repositori de GitHub de DLSS Swapper i proporciona la següent informació a la secció de context addicional.</value>
+  </data>
+  <data name="FailedToLaunchPage_WindowTitle" xml:space="preserve">
+    <value>No s'ha pogut iniciar</value>
+  </data>
+  <data name="GameHistoryControl_AssetTypeHeader" xml:space="preserve">
+    <value>Tipus d'actiu</value>
+  </data>
+  <data name="GameHistoryControl_EventTimeHeader" xml:space="preserve">
+    <value>Hora de l'esdeveniment</value>
+  </data>
+  <data name="GameHistoryControl_EventTypeHeader" xml:space="preserve">
+    <value>Tipus d'esdeveniment</value>
+  </data>
+  <data name="GameHistoryControl_NoHistoryLabel" xml:space="preserve">
+    <value>No s'ha trobat cap historial.</value>
+  </data>
+  <data name="GameHistoryControl_VersionHeader" xml:space="preserve">
+    <value>Versió</value>
+  </data>
+  <data name="GameHistoryEventType_DLLBackupRemoved" xml:space="preserve">
+    <value>S'ha eliminat la còpia de seguretat de la DLL</value>
+  </data>
+  <data name="GameHistoryEventType_DLLChangedExternally" xml:space="preserve">
+    <value>La DLL s'ha modificat externament</value>
+  </data>
+  <data name="GameHistoryEventType_DLLDetected" xml:space="preserve">
+    <value>DLL detectada</value>
+  </data>
+  <data name="GameHistoryEventType_DLLReset" xml:space="preserve">
+    <value>Restablir DLL</value>
+  </data>
+  <data name="GameHistoryEventType_DLLSwapped" xml:space="preserve">
+    <value>DLL intercanviada</value>
+  </data>
+  <data name="GameLibrary_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>No s'ha pogut carregar la biblioteca de jocs {0}</value>
+  </data>
+  <data name="GamePage_AddCustomCover" xml:space="preserve">
+    <value>Afegir portada personalitzada</value>
+  </data>
+  <data name="GamePage_ClickToFavorite" xml:space="preserve">
+    <value>Fes clic per afegir als preferits</value>
+  </data>
+  <data name="GamePage_CouldNotFindGameInstallPathTemplate" xml:space="preserve">
+    <value>No s'ha pogut trobar la ruta "{0}".</value>
+  </data>
+  <data name="GamePage_CurrentDll" xml:space="preserve">
+    <value>DLL actual</value>
+  </data>
+  <data name="GamePage_DllPicker_CouldNotFindFileTemplate" xml:space="preserve">
+    <value>No s'ha pogut trobar el fitxer "{0}".</value>
+  </data>
+  <data name="GamePage_DllPicker_ResetDllToVersionTemplate" xml:space="preserve">
+    <value>La DLL s'ha restablert a {0}.</value>
+  </data>
+  <data name="GamePage_DllPicker_StartingDownload" xml:space="preserve">
+    <value>S'està iniciant la descàrrega</value>
+  </data>
+  <data name="GamePage_DllPicker_WaitToDownloadBeforeSwapping" xml:space="preserve">
+    <value>Si us plau, espereu que la descàrrega s'acabi abans d'intercanviar</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo" xml:space="preserve">
+    <value>Informació del preset</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Message" xml:space="preserve">
+    <value>Els presets del DLSS es troben dins dels fitxers DLL de DLSS que es troben al directori d'instal·lació dels jocs. Diferents DLL de DLSS tenen presets diferents. Per exemple, el preset K no es va introduir fins a DLSS v310.2. Per tant, si utilitzeu DLSS v3.7 i definiu el preset a K, no utilitzarà el preset K i, en canvi, tornarà a qualsevol preset que el joc decideixi utilitzar.
+
+El mateix s'aplica als presets globals. Si seleccioneu el preset K però el vostre joc utilitza DLSS v3.7, no utilitzareu el preset K i, en canvi, el joc tornarà a la seva configuració predeterminada.
+
+Per verificar quin preset s'està utilitzant, activeu l'indicador de DLSS en pantalla.</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_OnScreenIndicator" xml:space="preserve">
+    <value>Informació de l'indicador en pantalla</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Title" xml:space="preserve">
+    <value>Informació del preset de DLSS</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Tooltip" xml:space="preserve">
+    <value>Establint un preset de DLSS no garanteix que el preset sigui utilitzat.</value>
+  </data>
+  <data name="GamePage_Favorited" xml:space="preserve">
+    <value>Afegit a preferits</value>
+  </data>
+  <data name="GamePage_History" xml:space="preserve">
+    <value>Historial</value>
+  </data>
+  <data name="GamePage_InstallPath" xml:space="preserve">
+    <value>Ruta d'instal·lació</value>
+  </data>
+  <data name="GamePage_InvalidFileTypeTemplate" xml:space="preserve">
+    <value>"{0}" és un tipus de fitxer no vàlid</value>
+  </data>
+  <data name="GamePage_Launch" xml:space="preserve">
+    <value>Iniciar</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_CantBeRemoved" xml:space="preserve">
+    <value>Aquest títol no ha sigut afegit manualment i no es pot eliminar.</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_RemoveGameTemplate" xml:space="preserve">
+    <value>Esteu segur que voleu eliminar "{0}" del DLSS Swapper? Això no farà cap canvi als fitxers DLSS que ja s'han intercanviat.</value>
+  </data>
+  <data name="GamePage_MultipleDllFound_Notice" xml:space="preserve">
+    <value>A continuació es mostren les diverses DLL trobades. Encara podreu intercanviar i restaurar les DLL com de costum, ja que farem aquestes accions a totes les DLL alhora. Tanmateix, com que no sabem quina d'aquestes DLL utilitza el joc, la versió de DLL que es mostra és de la primera DLL detectada.</value>
+  </data>
+  <data name="GamePage_MultipleDllsFound" xml:space="preserve">
+    <value>S'han trobat diverses DLL</value>
+  </data>
+  <data name="GamePage_MultipleDllsFoundTemplate" xml:space="preserve">
+    <value>S'han trobat diverses {0} DLL</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Message" xml:space="preserve">
+    <value>Si us plau, aneu a la pàgina de la biblioteca per descarregar noves DLL.</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Title" xml:space="preserve">
+    <value>No s'han trobat DLL</value>
+  </data>
+  <data name="GamePage_Notes" xml:space="preserve">
+    <value>Notes</value>
+  </data>
+  <data name="GamePage_NotReadyToPlayState" xml:space="preserve">
+    <value>Aquest joc no està en un estat llest per jugar.</value>
+  </data>
+  <data name="GamePage_OpenDllLocation" xml:space="preserve">
+    <value>Obre la ubicació de la DLL</value>
+  </data>
+  <data name="GamePage_OriginalDll" xml:space="preserve">
+    <value>DLL original</value>
+  </data>
+  <data name="GamePage_ProcessingPleaseWaitTemplate" xml:space="preserve">
+    <value>{0} encara s'està processant. Espereu que l'indicador de càrrega s'acabi abans d'obrir.</value>
+  </data>
+  <data name="GamePage_RestoreOriginalDll" xml:space="preserve">
+    <value>Restaurar la DLL original</value>
+  </data>
+  <data name="GamePage_SelectDllTemplateTitle" xml:space="preserve">
+    <value>Selecciona la versió {0}</value>
+  </data>
+  <data name="GamePage_StorageFileIsNull" xml:space="preserve">
+    <value>El fitxer d'emmagatzematge és nul</value>
+  </data>
+  <data name="GamePage_UnableToChangePreset" xml:space="preserve">
+    <value>No es pot canviar la configuració predefinida. Si us plau, consulteu el registre d'errors per obtenir més informació.</value>
+  </data>
+  <data name="GamePage_YouMayOnlyDragOneFileCover" xml:space="preserve">
+    <value>Només podeu arrossegar un sol fitxer per a una portada</value>
+  </data>
+  <data name="GamesPage_AddGame" xml:space="preserve">
+    <value>Afegir joc</value>
+  </data>
+  <data name="GamesPage_GroupGamesFromTheSameLibraryTogether" xml:space="preserve">
+    <value>Agrupa jocs de la mateixa biblioteca junts</value>
+  </data>
+  <data name="GamesPage_Grouping" xml:space="preserve">
+    <value>Agrupant</value>
+  </data>
+  <data name="GamesPage_HideGamesWithNoSwappableItems" xml:space="preserve">
+    <value>Amaga els jocs sense elements intercanviables</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AddCoverErrorSingleFile" xml:space="preserve">
+    <value>Només podeu arrossegar un sol fitxer per a una coberta</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AnotherNoteTitle" xml:space="preserve">
+    <value>Una altra nota per afegir jocs manualment</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_CouldntAddError" xml:space="preserve">
+    <value>Hi ha hagut un problema i no s'ha pogut afegir el teu joc en aquest moment. Si us plau, informa d'aquest problema.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_ErrorTitle" xml:space="preserve">
+    <value>S'ha produït un error en afegir el joc</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_InfoHtml" xml:space="preserve">
+    <value>Heu de seleccionar el directori &lt;i&gt;game&lt;/i&gt;, no el directori &lt;i&gt;games&lt;/i&gt;.&lt;br/&gt;&lt;br/&gt;Per exemple, si teniu un joc a:&lt;br/&gt;&lt;b&gt;C:\Program Files\MyGamesFolder\MyFavJoc\&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Hauríeu de seleccionar el directori &lt;b&gt;MyFavJoc&lt;/b&gt; i no el directori &lt;b&gt;MyGamesFolder&lt;/b&gt;.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteMessage" xml:space="preserve">
+    <value>DLSS Swapper hauria de trobar jocs de les biblioteques de jocs instal·lades automàticament. Si el vostre joc no apareix a la llista, pot haver-hi algunes opcions de configuració que ho impedeixin. Si us plau, comproveu:
+
+- El filtre de la llista de jocs no està configurat com a "Amaga els jocs sense elements intercanviables"
+- Una biblioteca de jocs específica està habilitada a la configuració
+
+Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi un error. Us agrairíem que informéssiu del problema al nostre repositori de GitHub perquè puguem solucionar-ho i que els vostres jocs es detectin millor en el futur.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteTitle" xml:space="preserve">
+    <value>Nota per afegir jocs manualment</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_PathExistsTemplate" xml:space="preserve">
+    <value>La ruta d'instal·lació "{0}" ja existeix i no es pot tornar a afegir.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_SelectGameFolder" xml:space="preserve">
+    <value>Selecciona la carpeta del joc</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_TopLevelDirectoryNotSupported" xml:space="preserve">
+    <value>No es permet afegir un directori de nivell superior. Si us plau, afegiu l'arrel del directori del joc.</value>
+  </data>
+  <data name="GamesPage_NewDlls" xml:space="preserve">
+    <value>Noves DLL</value>
+  </data>
+  <data name="GamesPage_NewDllsFound" xml:space="preserve">
+    <value>S'han trobat noves DLL</value>
+  </data>
+  <data name="GamesPage_NewDlls_CreateNewGitHubIssue" xml:space="preserve">
+    <value>Crea una nova incidència de GitHub</value>
+  </data>
+  <data name="GamesPage_NewDlls_DiscoveredHelpUs" xml:space="preserve">
+    <value>Mentre carregaves els jocs, s'han descobert algunes DLL noves que no es troben al manifest de l'intercanviador de DLSS.</value>
+  </data>
+  <data name="GamesPage_NewDlls_GitHubAccountRequired" xml:space="preserve">
+    <value>(Cal un compte de GitHub)</value>
+  </data>
+  <data name="GamesPage_NewDlls_IfButtonDoesntWorkTryHere" xml:space="preserve">
+    <value>Si el botó no funciona, prova aquí.</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepFourSubmitYourIssue" xml:space="preserve">
+    <value>Pas 4: Enviar el vostre problema</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepOneCreateNewIssue" xml:space="preserve">
+    <value>Pas 1: Crear un problema nou</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepThreeCopyBody" xml:space="preserve">
+    <value>Pas 3: Copiar el cos</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepTwoCopyTitle" xml:space="preserve">
+    <value>Pas 2: Copiar el títol</value>
+  </data>
+  <data name="GamesPage_NewDlls_ThanksForHelping" xml:space="preserve">
+    <value>Gràcies per ajudar!</value>
+  </data>
+  <data name="GamesPage_NewDlls_YouDoNotHaveToSubmitDllAutoTrack" xml:space="preserve">
+    <value>No cal que envieu les DLL. Les localitzarem en funció de la informació proporcionada.</value>
+  </data>
+  <data name="GamesPage_Title" xml:space="preserve">
+    <value>Games</value>
+  </data>
+  <data name="GamesPage_ViewType" xml:space="preserve">
+    <value>Tipus de vista</value>
+  </data>
+  <data name="GamesPage_ViewType_GridView" xml:space="preserve">
+    <value>Vista de quadrícula</value>
+  </data>
+  <data name="GamesPage_ViewType_ListView" xml:space="preserve">
+    <value>Vista de llista</value>
+  </data>
+  <data name="Game_AreYouSureRemoveCustomCover" xml:space="preserve">
+    <value>Esteu segur que voleu eliminar la imatge de la portada personalitzada?</value>
+  </data>
+  <data name="Game_CurrentlyProcessing" xml:space="preserve">
+    <value>Joc actualment en processament</value>
+  </data>
+  <data name="Game_CustomCoverRemove" xml:space="preserve">
+    <value>Voleu treure la portada personalitzada?</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeCatalog" xml:space="preserve">
+    <value>No s'ha pogut deserialitzar GOGCatalogResponse per a l'URL, {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeEmbedFilterResponse" xml:space="preserve">
+    <value>No s'ha pogut deserialitzar GOGEmbedFilteredResponse per a l'URL {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyEmbedFilteredProducts" xml:space="preserve">
+    <value>No s'ha trobat cap GOGEmbedFilteredProducts per a l'URL {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyProduct" xml:space="preserve">
+    <value>No s'ha trobat cap GOGCatalogProduct per a l'URL {0}</value>
+  </data>
+  <data name="Game_UbisoftConnect_CouldNotDetectInstallKey" xml:space="preserve">
+    <value>No s'ha pogut detectar la clau d'instal·lació d'Ubisoft Connect.</value>
+  </data>
+  <data name="Game_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>Biblioteca de jocs desconeguda {0} en configurar l'ID</value>
+  </data>
+  <data name="General_ApplicationRunningAsAdmin" xml:space="preserve">
+    <value>Aquesta aplicació s'està executant amb privilegis d'administrador.</value>
+  </data>
+  <data name="General_Apply" xml:space="preserve">
+    <value>Aplicar</value>
+  </data>
+  <data name="General_Cancel" xml:space="preserve">
+    <value>Cancel·lar</value>
+  </data>
+  <data name="General_Close" xml:space="preserve">
+    <value>Tancar</value>
+  </data>
+  <data name="General_Copy" xml:space="preserve">
+    <value>Copiar</value>
+  </data>
+  <data name="General_Delete" xml:space="preserve">
+    <value>Suprimir</value>
+  </data>
+  <data name="General_DontShowAgain" xml:space="preserve">
+    <value>No tornar a mostrar</value>
+  </data>
+  <data name="General_Error" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="General_ErrorMessage" xml:space="preserve">
+    <value>Missatge d'error</value>
+  </data>
+  <data name="General_Export" xml:space="preserve">
+    <value>Exportar</value>
+  </data>
+  <data name="General_ExportAll" xml:space="preserve">
+    <value>Exportat tot</value>
+  </data>
+  <data name="General_Failed" xml:space="preserve">
+    <value>Fallat</value>
+  </data>
+  <data name="General_FeatureNotSupportedWhenAdmin" xml:space="preserve">
+    <value>Aquesta funció no és compatible si executeu l'aplicació com a administrador.</value>
+  </data>
+  <data name="General_Filter" xml:space="preserve">
+    <value>Filtre</value>
+  </data>
+  <data name="General_Help" xml:space="preserve">
+    <value>Ajuda</value>
+  </data>
+  <data name="General_Import" xml:space="preserve">
+    <value>Importar</value>
+  </data>
+  <data name="General_Load" xml:space="preserve">
+    <value>Carregar</value>
+  </data>
+  <data name="General_Loading" xml:space="preserve">
+    <value>Carregant</value>
+  </data>
+  <data name="General_Name" xml:space="preserve">
+    <value>Nom</value>
+  </data>
+  <data name="General_No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="General_None" xml:space="preserve">
+    <value>Cap</value>
+  </data>
+  <data name="General_NotSupported" xml:space="preserve">
+    <value>No compatible</value>
+  </data>
+  <data name="General_Okay" xml:space="preserve">
+    <value>D'acord</value>
+  </data>
+  <data name="General_Oops" xml:space="preserve">
+    <value>Ups</value>
+  </data>
+  <data name="General_OpenFolder" xml:space="preserve">
+    <value>Obrir carpeta</value>
+  </data>
+  <data name="General_Optional" xml:space="preserve">
+    <value>(opcional)</value>
+  </data>
+  <data name="General_Options" xml:space="preserve">
+    <value>Opcions</value>
+  </data>
+  <data name="General_Publish" xml:space="preserve">
+    <value>Publicar</value>
+  </data>
+  <data name="General_Refresh" xml:space="preserve">
+    <value>Actualizar</value>
+  </data>
+  <data name="General_Reload" xml:space="preserve">
+    <value>Tornar a carregar</value>
+  </data>
+  <data name="General_Remove" xml:space="preserve">
+    <value>Eliminar</value>
+  </data>
+  <data name="General_ReportIssue" xml:space="preserve">
+    <value>Informar d'un problema</value>
+  </data>
+  <data name="General_Save" xml:space="preserve">
+    <value>Desar</value>
+  </data>
+  <data name="General_Search" xml:space="preserve">
+    <value>Cercar</value>
+  </data>
+  <data name="General_Sorry" xml:space="preserve">
+    <value>Perdó</value>
+  </data>
+  <data name="General_Success" xml:space="preserve">
+    <value>Êxit</value>
+  </data>
+  <data name="General_Swap" xml:space="preserve">
+    <value>Intercanviar</value>
+  </data>
+  <data name="General_Unknown" xml:space="preserve">
+    <value>Desconegut</value>
+  </data>
+  <data name="General_Update" xml:space="preserve">
+    <value>Actualització</value>
+  </data>
+  <data name="General_Version" xml:space="preserve">
+    <value>Versió</value>
+  </data>
+  <data name="General_Warning" xml:space="preserve">
+    <value>Avís</value>
+  </data>
+  <data name="General_Yes" xml:space="preserve">
+    <value>Sí</value>
+  </data>
+  <data name="GitHubUpdater_CouldNotLoadGitHubReleaseDataException" xml:space="preserve">
+    <value>No s'han pogut carregar les dades de la versió de GitHub.</value>
+  </data>
+  <data name="GitHubUpdater_CurrentVersionIsActualTemplate" xml:space="preserve">
+    <value>Actualment teniu {0} instal·lat.</value>
+  </data>
+  <data name="GitHubUpdater_DlssSwapperUpdated" xml:space="preserve">
+    <value>DLSS Swapper s'acaba d'actualitzar</value>
+  </data>
+  <data name="GitHubUpdater_UpdateAvailable" xml:space="preserve">
+    <value>Actualització disponible</value>
+  </data>
+  <data name="LibraryPage_AlreadyDownloaded" xml:space="preserve">
+    <value>Ja s'ha descarregat.</value>
+  </data>
+  <data name="LibraryPage_CouldNotLoadImportedDlls" xml:space="preserve">
+    <value>No s'han pogut carregar les DLL importades</value>
+  </data>
+  <data name="LibraryPage_CouldntDownload" xml:space="preserve">
+    <value>No s'ha pogut descarregar en aquest moment.</value>
+  </data>
+  <data name="LibraryPage_CouldntExportDll" xml:space="preserve">
+    <value>No s'han pogut exportar les DLL.</value>
+  </data>
+  <data name="LibraryPage_DeleteDll" xml:space="preserve">
+    <value>Suprimeix la DLL</value>
+  </data>
+  <data name="LibraryPage_DeleteDllVersionTemplate" xml:space="preserve">
+    <value>Voleu suprimir {0} v{1}?</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_DownloadFileSize" xml:space="preserve">
+    <value>Mida del fitxer de descàrrega</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileDescription" xml:space="preserve">
+    <value>Descripció del fitxer</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileSize" xml:space="preserve">
+    <value>Mida del fitxer</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalName" xml:space="preserve">
+    <value>Nom intern</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalNameExtra" xml:space="preserve">
+    <value>Nom intern addicional</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Label" xml:space="preserve">
+    <value>Etiqueta</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Message" xml:space="preserve">
+    <value>Started {0} new downloads.</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Title" xml:space="preserve">
+    <value>Descàrregues iniciades</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLs" xml:space="preserve">
+    <value>DLL exportades:</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLsCount_Message" xml:space="preserve">
+    <value>S'han exportat {0} DLL.</value>
+  </data>
+  <data name="LibraryPage_ExportedDllTemplate" xml:space="preserve">
+    <value>DLL exportada {0}.</value>
+  </data>
+  <data name="LibraryPage_FileNotFound" xml:space="preserve">
+    <value>No s'ha trobat el fitxer.</value>
+  </data>
+  <data name="LibraryPage_Finished" xml:space="preserve">
+    <value>Acabat</value>
+  </data>
+  <data name="LibraryPage_ImportedAsExistingRecord" xml:space="preserve">
+    <value>Importat com a registre DLL existent.</value>
+  </data>
+  <data name="LibraryPage_Importing" xml:space="preserve">
+    <value>S'està important</value>
+  </data>
+  <data name="LibraryPage_MaliciousDllsInfo" xml:space="preserve">
+    <value>Substituir fitxers DLL a l'ordinador pot ser perillós.
+
+Posar un fitxer DLL maliciós en un joc és tan dolent com executar Linking_park_-_nUmB_mp3.exe que acabes de descarregar de LimeWire.
+
+Només importa fitxers DLL de fonts de confiança.</value>
+  </data>
+  <data name="LibraryPage_NoDLLsForExport_Message" xml:space="preserve">
+    <value>No DLLs found for export.</value>
+  </data>
+  <data name="LibraryPage_NoDllsToExport" xml:space="preserve">
+    <value>No teniu cap registre DLL per exportar.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Message" xml:space="preserve">
+    <value>No hi havia noves DLL per descarregar.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Title" xml:space="preserve">
+    <value>No hi ha noves DLL</value>
+  </data>
+  <data name="LibraryPage_ProcessedDlls" xml:space="preserve">
+    <value>DLL processades:</value>
+  </data>
+  <data name="LibraryPage_Title" xml:space="preserve">
+    <value>Biblioteca</value>
+  </data>
+  <data name="LibraryPage_UnableToDeleteRecord" xml:space="preserve">
+    <value>No s'ha pogut suprimir el registre {0}.</value>
+  </data>
+  <data name="LibraryPage_UnableToUpdateDllRecord" xml:space="preserve">
+    <value>No s'han pogut actualitzar els registres DLL.</value>
+  </data>
+  <data name="LibraryPage_ZipDidNotContainAnyDlls" xml:space="preserve">
+    <value>El zip no contenia cap DLL.</value>
+  </data>
+  <data name="MainWindow_AttemptingManifestUpdate" xml:space="preserve">
+    <value>Intentant actualitzar</value>
+  </data>
+  <data name="MainWindow_DlssSwapperCloseDueToManifest" xml:space="preserve">
+    <value>El DLSS Swapper no ha pogut carregar el seu fitxer de manifest. Ara es tancarà.</value>
+  </data>
+  <data name="MainWindow_DlssSwapperMustClose" xml:space="preserve">
+    <value>El DLSS Swapper s'ha de tancar</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_GitHubIssues" xml:space="preserve">
+    <value>Incidències de GitHub</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_Message" xml:space="preserve">
+    <value>No hem pogut carregar manifest.json des del vostre ordinador ni des d'Internet.
+
+Si això continua passant, envieu un informe al nostre rastrejador d'incidències a GitHub.</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_UpdateManifest" xml:space="preserve">
+    <value>Actualitzar el manifest</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Message" xml:space="preserve">
+    <value>Tot i que l'intercanvi de versions de DLSS no s'ha de considerar una trampa, és possible que alguns sistemes antitrampa no estiguin contents amb tu si els fitxers del directori del joc no són els que s'hi van distribuir.
+
+Per això, recomanem anar amb compte amb les partides multijugador.</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Title" xml:space="preserve">
+    <value>Nota per a jocs multijugador</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterStillDoesNotWork" xml:space="preserve">
+    <value>Encara no funciona</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterWorks" xml:space="preserve">
+    <value>Funciona!</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTestTitle" xml:space="preserve">
+    <value>Prova del navegador</value>
+  </data>
+  <data name="NetworkTesterPage_CancelCurrentTest" xml:space="preserve">
+    <value>Cancel·lar la prova actual</value>
+  </data>
+  <data name="NetworkTesterPage_CopyTestResults" xml:space="preserve">
+    <value>Copiar els resultats de la prova</value>
+  </data>
+  <data name="NetworkTesterPage_CreateBugReport" xml:space="preserve">
+    <value>Crea un informe d'errors</value>
+  </data>
+  <data name="NetworkTesterPage_CustomUserAgentTest" xml:space="preserve">
+    <value>Prova d'agent d'usuari personalitzada</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest10Title" xml:space="preserve">
+    <value>Descarregant la DLL del DLSS Swapper dins de DLSS Swapper amb un agent d'usuari personalitzat</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest11Title" xml:space="preserve">
+    <value>Descarregant la DLL del DLSS des del mirall d'UploadThing</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest1Title" xml:space="preserve">
+    <value>Accedint a google.com des de DLSS Swapper (prova de la connectivitat general a Internet)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest2Title" xml:space="preserve">
+    <value>Accedint a bing.com des de DLSS Swapper (prova de la connectivitat general a Internet)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest3Title" xml:space="preserve">
+    <value>Descarregant la DLL del DLSS Swapper dins de DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest4Title" xml:space="preserve">
+    <value>Descarregant la DLL del DLSS Swapper des del navegador</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest5Title" xml:space="preserve">
+    <value>Descarregant la portada del joc des de Steam</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest6Title" xml:space="preserve">
+    <value>Descarregant la portada del joc de l'Epic Game Store</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest7Title" xml:space="preserve">
+    <value>Downloading game cover from DLSS Swapper file server</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest8Title" xml:space="preserve">
+    <value>Descarregant la portada del joc des d'un servidor de fitxers DLSS Swapper alternatiu</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest9Title" xml:space="preserve">
+    <value>Cerca DNS del servidor de fitxers DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowser" xml:space="preserve">
+    <value>Obrir al navegador</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowserInfo" xml:space="preserve">
+    <value>Feu clic al botó obrir al navegador o copieu i enganxeu l'enllaç següent al vostre navegador. Es descarrega algun fitxer al vostre navegador?</value>
+  </data>
+  <data name="NetworkTesterPage_Results" xml:space="preserve">
+    <value>Resultats</value>
+  </data>
+  <data name="NetworkTesterPage_RunTest" xml:space="preserve">
+    <value>Executar la prova</value>
+  </data>
+  <data name="NetworkTesterPage_UseUserAgentInfo" xml:space="preserve">
+    <value>Feu servir l'agent d'usuari proporcionat o introduïu-ne un de personalitzat que trieu.</value>
+  </data>
+  <data name="NetworkTesterPage_WindowTitle" xml:space="preserve">
+    <value>Provador de xarxa</value>
+  </data>
+  <data name="SettingsPage_About" xml:space="preserve">
+    <value>Sobre</value>
+  </data>
+  <data name="SettingsPage_AddIgnoredPath" xml:space="preserve">
+    <value>Afegeix una ruta ignorada</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDlls" xml:space="preserve">
+    <value>Permetre DLL de depuració</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDllsInfo" xml:space="preserve">
+    <value>Els SDK de vegades publiquen DLL de depuració que permeten mostrar informació addicional en pantalla.</value>
+  </data>
+  <data name="SettingsPage_AllowUntrustedInfo" xml:space="preserve">
+    <value>Es comprova si les DLL són de confiança a Windows validant la signatura abans de canviar-les a una carpeta de joc. Si una DLL falla la validació de la signatura, no s'utilitzarà. Es recomana mantenir-ho desactivat.</value>
+  </data>
+  <data name="SettingsPage_AppliesOnlyToDllPickerNotLibrary" xml:space="preserve">
+    <value>Això només s'aplica al selector de DLL, no a la pàgina de la biblioteca.</value>
+  </data>
+  <data name="SettingsPage_CouldNotOpenLogFileTryManual" xml:space="preserve">
+    <value>No s'ha pogut obrir el fitxer de registre directament des de DLSS Swapper. Si us plau, proveu d'obrir-lo manualment.</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathMessage" xml:space="preserve">
+    <value>Esteu segur que voleu suprimir el camí ignorat {0}?</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathTitle" xml:space="preserve">
+    <value>Suprimeix la ruta ignorada</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions" xml:space="preserve">
+    <value>Opcions de desenvolupador de DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToConsoleWindow" xml:space="preserve">
+    <value>Habilita el registre a la finestra de la consola</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToFile" xml:space="preserve">
+    <value>Habilita el registre al fitxer</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForAllDlssDlls" xml:space="preserve">
+    <value>Activat per a totes les DLL de DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForDebugDlssDllOnly" xml:space="preserve">
+    <value>Només habilitat per a DLL de DLSS de depuració</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_ShowOnScreenIndicator" xml:space="preserve">
+    <value>Mostra l'indicador en pantalla</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_VerboseLogging" xml:space="preserve">
+    <value>Registre detallat</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions" xml:space="preserve">
+    <value>Opcions de DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions_GlobalPreset" xml:space="preserve">
+    <value>Preset global</value>
+  </data>
+  <data name="SettingsPage_GameLibraries" xml:space="preserve">
+    <value>Biblioteques de jocs</value>
+  </data>
+  <data name="SettingsPage_GeneralTroubleshootingGuide" xml:space="preserve">
+    <value>Guia general de resolució de problemes</value>
+  </data>
+  <data name="SettingsPage_GiveFeedback" xml:space="preserve">
+    <value>Donar comentaris</value>
+  </data>
+  <data name="SettingsPage_GiveFeedbackInfo" xml:space="preserve">
+    <value>Podeu suggerir una funció o informar d'un problema al DLSS Swapper</value>
+  </data>
+  <data name="SettingsPage_IgnoredPaths" xml:space="preserve">
+    <value>Rutes ignorades</value>
+  </data>
+  <data name="SettingsPage_Language" xml:space="preserve">
+    <value>Llengua</value>
+  </data>
+  <data name="SettingsPage_LibraryDisabled" xml:space="preserve">
+    <value>{0} desactivat</value>
+  </data>
+  <data name="SettingsPage_LibraryEnabled" xml:space="preserve">
+    <value>{0} activat</value>
+  </data>
+  <data name="SettingsPage_Logging" xml:space="preserve">
+    <value>Registre</value>
+  </data>
+  <data name="SettingsPage_NoNewUpdatesAvailable" xml:space="preserve">
+    <value>No hi ha noves actualitzacions disponibles.</value>
+  </data>
+  <data name="SettingsPage_OpenAcknowledgements" xml:space="preserve">
+    <value>Agraïments</value>
+  </data>
+  <data name="SettingsPage_OpenDiagnostics" xml:space="preserve">
+    <value>Diagnòstics</value>
+  </data>
+  <data name="SettingsPage_OpenNetworkTester" xml:space="preserve">
+    <value>Provador de xarxa</value>
+  </data>
+  <data name="SettingsPage_OpenTranslationToolbox" xml:space="preserve">
+    <value>Caixa d'eines de traducció oberta</value>
+  </data>
+  <data name="SettingsPage_PathAlreadyIgnored" xml:space="preserve">
+    <value>El camí {0} ja s'ha ignorat.</value>
+  </data>
+  <data name="SettingsPage_SettingsAllowUntrusted" xml:space="preserve">
+    <value>Permet fonts no fiables</value>
+  </data>
+  <data name="SettingsPage_SettingsCheckForUpdates" xml:space="preserve">
+    <value>Comprova si hi ha actualitzacions</value>
+  </data>
+  <data name="SettingsPage_ShowOnlyDownloadedDlls" xml:space="preserve">
+    <value>Mostra només les DLL descarregades</value>
+  </data>
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
+    <value>Fosc</value>
+  </data>
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
+    <value>Clar</value>
+  </data>
+  <data name="SettingsPage_ThemeMode" xml:space="preserve">
+    <value>Mode del tema</value>
+  </data>
+  <data name="SettingsPage_ThemeSystemSettingDefault" xml:space="preserve">
+    <value>Utilitza la configuració del sistema</value>
+  </data>
+  <data name="SettingsPage_Title" xml:space="preserve">
+    <value>Configuració</value>
+  </data>
+  <data name="SettingsPage_Troubleshooting" xml:space="preserve">
+    <value>Resolució de problemes</value>
+  </data>
+  <data name="SettingsPage_YourCurrentLogFile" xml:space="preserve">
+    <value>El vostre fitxer de registre actual és</value>
+  </data>
+  <data name="TranslationToolboxPage_AdminError" xml:space="preserve">
+    <value>No podeu utilitzar l'eina de traducció mentre s'executa com a administrador. Reinicieu l'aplicació.</value>
+  </data>
+  <data name="TranslationToolboxPage_Comment" xml:space="preserve">
+    <value>Comentari</value>
+  </data>
+  <data name="TranslationToolboxPage_ImportAsTranslation" xml:space="preserve">
+    <value>Importa l'idioma com a traducció</value>
+  </data>
+  <data name="TranslationToolboxPage_Key" xml:space="preserve">
+    <value>Clau</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadExistingTranslation" xml:space="preserve">
+    <value>Carrega existent</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadFailedMessage" xml:space="preserve">
+    <value>No s'ha pogut carregar la traducció. Consulteu el registre d'errors per obtenir més informació.</value>
+  </data>
+  <data name="TranslationToolboxPage_NewTranslation" xml:space="preserve">
+    <value>Nova traducció</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToPublish" xml:space="preserve">
+    <value>No s'han trobat dades de traducció per publicar.</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToSave" xml:space="preserve">
+    <value>No s'han trobat dades de traducció per desar.</value>
+  </data>
+  <data name="TranslationToolboxPage_NotValidTranslationFile" xml:space="preserve">
+    <value>No s'han trobat dades de traducció per desar.</value>
+  </data>
+  <data name="TranslationToolboxPage_PublishFailedMessage" xml:space="preserve">
+    <value>No s'ha pogut publicar la traducció. Consulteu el registre d'errors per obtenir més informació.</value>
+  </data>
+  <data name="TranslationToolboxPage_ReloadApp" xml:space="preserve">
+    <value>Torna a carregar l'aplicació</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressButton" xml:space="preserve">
+    <value>Restablir i continuar</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressMessage" xml:space="preserve">
+    <value>Això restablirà el progrés actual de la traducció. Esteu segur que voleu continuar?</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressTitle" xml:space="preserve">
+    <value>Voleu restablir el progrés i continuar?</value>
+  </data>
+  <data name="TranslationToolboxPage_SaveFailedMessage" xml:space="preserve">
+    <value>No s'ha pogut desar la traducció. Consulteu el registre d'errors per obtenir més informació.</value>
+  </data>
+  <data name="TranslationToolboxPage_SelectLanguageToLoad" xml:space="preserve">
+    <value>Selecciona l'idioma per carregar</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceLanguage" xml:space="preserve">
+    <value>Idioma d'origen</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceTranslation" xml:space="preserve">
+    <value>Traducció original</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideButton" xml:space="preserve">
+    <value>Guia de traducció</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideMessage" xml:space="preserve">
+    <value>La vostra traducció s'ha creat. Consulteu la guia de traducció de DLSS Swapper per saber què cal fer a continuació amb {0}.</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationProgress" xml:space="preserve">
+    <value>Progrés de la traducció</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesButton" xml:space="preserve">
+    <value>Tanca sense desar</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesMessage" xml:space="preserve">
+    <value>És possible que tingueu canvis de traducció no desats. Si tanqueu aquesta finestra, es perdran.</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesTitle" xml:space="preserve">
+    <value>Canvis de traducció no desats</value>
+  </data>
+  <data name="TranslationToolboxPage_WindowTitle" xml:space="preserve">
+    <value>Caixa d'eines de traducció</value>
+  </data>
+</root>


### PR DESCRIPTION
## Description of Changes

Adds a full Catalan translation for DLSS Swapper interface, as a selectable translation in settings.

<img width="2560" height="1392" alt="DLSS Swapper 14_7_2025 17_44_51" src="https://github.com/user-attachments/assets/f9d3a7ec-bfee-4c43-9b6e-468130ffb056" />


## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Issues Resolved

None.