### PR TITLE
Add Italian language support

### DIFF
--- a/src/Helpers/LanguageManager.cs
+++ b/src/Helpers/LanguageManager.cs
@@ -48,6 +48,7 @@ public class LanguageManager
             "en-AU",
             "en-GB",
             "en-US",
+            "it-IT",
             "fr-FR",
             "pl-PL",
             "pt-BR",
@@ -72,6 +73,7 @@ public class LanguageManager
             "en-AU" => "English (Australia)",
             "en-GB" => "English (United Kingdom)",
             "en-US" => "English (United States)",
+            "it-IT" => "Italiano", // Italian
             "fr-FR" => "French (France)", // French (France)
             "pl-PL" => "Polish",
             "pt-BR" => "Português BR",

--- a/src/Translations/it-IT/Resources.resw
+++ b/src/Translations/it-IT/Resources.resw
@@ -1,0 +1,1001 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="AcknowledgementsPage_Title" xml:space="preserve">
+    <value>Licenze e riconoscimenti</value>
+  </data>
+  <data name="ApplicationTitle" xml:space="preserve">
+    <value>DLSS Swapper</value>
+  </data>
+  <data name="DiagnosticsPage_ClickToCopyDetails" xml:space="preserve">
+    <value>Fare clic per copiare i dettagli sottostanti</value>
+  </data>
+  <data name="DiagnosticsPage_WindowTitle" xml:space="preserve">
+    <value>Diagnostica</value>
+  </data>
+  <data name="DllManager_AlreadyImported" xml:space="preserve">
+    <value>(già importato)</value>
+  </data>
+  <data name="DllManager_CouldNotDeserializeManifestException" xml:space="preserve">
+    <value>Impossibile deserializzare manifest.json.</value>
+  </data>
+  <data name="DllManager_ImportFeatureDisabled" xml:space="preserve">
+    <value>La funzionalità di importazione è disabilitata, non è stato possibile caricare il manifesto di importazione.</value>
+  </data>
+  <data name="DllManager_MigratingDlls" xml:space="preserve">
+    <value>Migrazione delle DLL</value>
+  </data>
+  <data name="DllManager_UnknownTypeDll" xml:space="preserve">
+    <value>DLL non è un tipo noto.</value>
+  </data>
+  <data name="DllManager_UntrustedDll" xml:space="preserve">
+    <value>La DLL non è considerata attendibile da Windows.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
+    <value>Impossibile scaricare {0} DLL. Riprova più tardi o controlla i registri per scoprire perché il download non è riuscito.</value>
+  </data>
+  <data name="DllRecord_CouldNotDownloadFile" xml:space="preserve">
+    <value>Impossibile scaricare il file.</value>
+  </data>
+  <data name="DllRecord_Download" xml:space="preserve">
+    <value>Scarica</value>
+  </data>
+  <data name="DllRecord_DownloadError" xml:space="preserve">
+    <value>Errore di download</value>
+  </data>
+  <data name="DllRecord_DownloadFileWasInvalid" xml:space="preserve">
+    <value>Il file scaricato non è valido.</value>
+  </data>
+  <data name="DllRecord_Downloading" xml:space="preserve">
+    <value>Scaricamento</value>
+  </data>
+  <data name="DllRecord_Imported" xml:space="preserve">
+    <value>Importata</value>
+  </data>
+  <data name="DllRecord_RequiresDownload" xml:space="preserve">
+    <value>Richiede il download</value>
+  </data>
+  <data name="DllZipInvalidNoDllFound" xml:space="preserve">
+    <value>Il file zip della DLL non è valido (nessuna DLL trovata).</value>
+  </data>
+  <data name="FailedToLaunchPage_DlssSwapperFailedToLaunch" xml:space="preserve">
+    <value>DLSS Swapper non è riuscito ad avviarsi</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial1" xml:space="preserve">
+    <value>Per favore apri un </value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial2" xml:space="preserve">
+    <value>nuovo issue</value>
+  </data>
+  <data name="FailedToLaunchPage_PleaseOpenIssuePartial3" xml:space="preserve">
+    <value> sul repository GitHub di DLSS Swapper e fornire le seguenti informazioni nella sezione di contesto aggiuntivo.</value>
+  </data>
+  <data name="FailedToLaunchPage_WindowTitle" xml:space="preserve">
+    <value>Impossibile avviare</value>
+  </data>
+  <data name="GameHistoryControl_AssetTypeHeader" xml:space="preserve">
+    <value>Tipo di risorsa</value>
+  </data>
+  <data name="GameHistoryControl_EventTimeHeader" xml:space="preserve">
+    <value>Ora dell'evento</value>
+  </data>
+  <data name="GameHistoryControl_EventTypeHeader" xml:space="preserve">
+    <value>Tipo di evento</value>
+  </data>
+  <data name="GameHistoryControl_NoHistoryLabel" xml:space="preserve">
+    <value>Nessuna cronologia trovata.</value>
+  </data>
+  <data name="GameHistoryControl_VersionHeader" xml:space="preserve">
+    <value>Versione</value>
+  </data>
+  <data name="GameHistoryEventType_DLLBackupRemoved" xml:space="preserve">
+    <value>Backup DLL rimosso</value>
+  </data>
+  <data name="GameHistoryEventType_DLLChangedExternally" xml:space="preserve">
+    <value>La DLL è stata modificata esternamente</value>
+  </data>
+  <data name="GameHistoryEventType_DLLDetected" xml:space="preserve">
+    <value>DLL rilevata</value>
+  </data>
+  <data name="GameHistoryEventType_DLLReset" xml:space="preserve">
+    <value>Ripristino DLL</value>
+  </data>
+  <data name="GameHistoryEventType_DLLSwapped" xml:space="preserve">
+    <value>DLL scambiata</value>
+  </data>
+  <data name="GameLibrary_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>Impossibile caricare la libreria di giochi {0}</value>
+  </data>
+  <data name="GamePage_AddCustomCover" xml:space="preserve">
+    <value>Aggiungi copertina personalizzata</value>
+  </data>
+  <data name="GamePage_ClickToFavorite" xml:space="preserve">
+    <value>Clicca per aggiungere ai preferiti</value>
+  </data>
+  <data name="GamePage_CouldNotFindGameInstallPathTemplate" xml:space="preserve">
+    <value>Impossibile trovare il percorso "{0}".</value>
+  </data>
+  <data name="GamePage_CurrentDll" xml:space="preserve">
+    <value>DLL corrente</value>
+  </data>
+  <data name="GamePage_DllPicker_CouldNotFindFileTemplate" xml:space="preserve">
+    <value>Impossibile trovare il file "{0}".</value>
+  </data>
+  <data name="GamePage_DllPicker_ResetDllToVersionTemplate" xml:space="preserve">
+    <value>La DLL è stata reimpostata su {0}.</value>
+  </data>
+  <data name="GamePage_DllPicker_StartingDownload" xml:space="preserve">
+    <value>Avvio del download</value>
+  </data>
+  <data name="GamePage_DllPicker_WaitToDownloadBeforeSwapping" xml:space="preserve">
+    <value>Attendi il completamento del download prima di effettuare lo scambio</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo" xml:space="preserve">
+    <value>Preset information</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Message" xml:space="preserve">
+    <value>I preset DLSS sono contenuti nei file DLL DLSS presenti nella directory di installazione del gioco. DLL DLSS diverse hanno preset diversi. Ad esempio, il preset K non è stato introdotto fino a DLSS v310.2. Quindi, se si utilizza DLSS v3.7 e si imposta il preset su K, non verrà utilizzato il preset K e verrà invece utilizzato il preset scelto dal gioco.
+
+Lo stesso vale per i preset globali. Se si seleziona il preset K ma il gioco utilizza DLSS v3.7, non verrà utilizzato il preset K e il gioco tornerà al suo valore predefinito.
+
+Per verificare quale preset viene utilizzato, abilitare l'indicatore DLSS a schermo.</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_OnScreenIndicator" xml:space="preserve">
+    <value>Informazioni sull'indicatore sullo schermo</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Title" xml:space="preserve">
+    <value>Informazioni preimpostate DLSS</value>
+  </data>
+  <data name="GamePage_DLSSPresetInfo_Tooltip" xml:space="preserve">
+    <value>L'impostazione di un preset DLSS non garantisce che il preset venga utilizzato.</value>
+  </data>
+  <data name="GamePage_Favorited" xml:space="preserve">
+    <value>Preferito</value>
+  </data>
+  <data name="GamePage_History" xml:space="preserve">
+    <value>Storiale</value>
+  </data>
+  <data name="GamePage_InstallPath" xml:space="preserve">
+    <value>Percorso di installazione</value>
+  </data>
+  <data name="GamePage_InvalidFileTypeTemplate" xml:space="preserve">
+    <value>"{0}" è un tipo di file non valido</value>
+  </data>
+  <data name="GamePage_Launch" xml:space="preserve">
+    <value>Lanciare</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_CantBeRemoved" xml:space="preserve">
+    <value>Questo titolo non è stato aggiunto manualmente e non può essere rimosso.</value>
+  </data>
+  <data name="GamePage_ManuallyAdded_RemoveGameTemplate" xml:space="preserve">
+    <value>Vuoi davvero rimuovere "{0}" da DLSS Swapper? Questo non apporterà alcuna modifica ai file DLSS già scambiati.</value>
+  </data>
+  <data name="GamePage_MultipleDllFound_Notice" xml:space="preserve">
+    <value>Di seguito sono mostrate le varie DLL rilevate. Sarà comunque possibile scambiare e ripristinare le DLL come di consueto, poiché queste azioni verranno eseguite su tutte le DLL contemporaneamente. Tuttavia, poiché non sappiamo quale di queste DLL venga utilizzata dal gioco, la versione DLL mostrata è quella della prima DLL rilevata.</value>
+  </data>
+  <data name="GamePage_MultipleDllsFound" xml:space="preserve">
+    <value>Sono state trovate più DLL</value>
+  </data>
+  <data name="GamePage_MultipleDllsFoundTemplate" xml:space="preserve">
+    <value>Trovati più DLL {0}</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Message" xml:space="preserve">
+    <value>Per scaricare le nuove DLL, vai alla pagina della biblioteca.</value>
+  </data>
+  <data name="GamePage_NoDllsFoundError_Title" xml:space="preserve">
+    <value>Nessuna DLL trovata</value>
+  </data>
+  <data name="GamePage_Notes" xml:space="preserve">
+    <value>Note</value>
+  </data>
+  <data name="GamePage_NotReadyToPlayState" xml:space="preserve">
+    <value>Questo gioco non è pronto per essere giocato.</value>
+  </data>
+  <data name="GamePage_OpenDllLocation" xml:space="preserve">
+    <value>Apri la posizione della DLL</value>
+  </data>
+  <data name="GamePage_OriginalDll" xml:space="preserve">
+    <value>DLL originale</value>
+  </data>
+  <data name="GamePage_ProcessingPleaseWaitTemplate" xml:space="preserve">
+    <value>{0} è ancora in fase di elaborazione. Per favore, attendi il completamento dell'indicatore di caricamento prima di aprire.</value>
+  </data>
+  <data name="GamePage_RestoreOriginalDll" xml:space="preserve">
+    <value>Ripristina la DLL originale</value>
+  </data>
+  <data name="GamePage_SelectDllTemplateTitle" xml:space="preserve">
+    <value>Seleziona la versione {0}</value>
+  </data>
+  <data name="GamePage_StorageFileIsNull" xml:space="preserve">
+    <value>storageFile è nullo</value>
+  </data>
+  <data name="GamePage_UnableToChangePreset" xml:space="preserve">
+    <value>Impossibile modificare il preset. Consulta il registro degli errori per ulteriori informazioni.</value>
+  </data>
+  <data name="GamePage_YouMayOnlyDragOneFileCover" xml:space="preserve">
+    <value>È possibile trascinare solo un singolo file per una copertina</value>
+  </data>
+  <data name="GamesPage_AddGame" xml:space="preserve">
+    <value>Aggiungi gioco</value>
+  </data>
+  <data name="GamesPage_GroupGamesFromTheSameLibraryTogether" xml:space="preserve">
+    <value>Raggruppare i giochi della stessa libreria insieme</value>
+  </data>
+  <data name="GamesPage_Grouping" xml:space="preserve">
+    <value>Raggruppando</value>
+  </data>
+  <data name="GamesPage_HideGamesWithNoSwappableItems" xml:space="preserve">
+    <value>Nascondi i giochi senza elementi scambiabili</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AddCoverErrorSingleFile" xml:space="preserve">
+    <value>È possibile trascinare solo un singolo file per una copertina</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_AnotherNoteTitle" xml:space="preserve">
+    <value>Un'altra nota per l'aggiunta manuale di giochi</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_CouldntAddError" xml:space="preserve">
+    <value>Si è verificato un problema e al momento non è stato possibile aggiungere il tuo gioco. Per favore, segnala il problema.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_ErrorTitle" xml:space="preserve">
+    <value>Errore durante l'aggiunta del gioco</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_InfoHtml" xml:space="preserve">
+    <value>Devi selezionare la directory &lt;i&gt;gioco&lt;/i&gt;, non la directory &lt;i&gt;giochi&lt;/i&gt;.&lt;br/&gt;&lt;br/&gt;Ad esempio, se hai un gioco in:&lt;br/&gt;&lt;b&gt;C:\Programmi\CartellaGiochi\CartellaGiochiFacoltativa\&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;Dovresti selezionare la directory &lt;b&gt;CartellaGiochiFacoltativa&lt;/b&gt; e non la directory &lt;b&gt;CartellaGiochiFacoltativa&lt;/b&gt;.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteMessage" xml:space="preserve">
+    <value>DLSS Swapper dovrebbe trovare automaticamente i giochi dalle librerie installate. Se il tuo gioco non è presente nell'elenco, potrebbero esserci alcune impostazioni che lo impediscono. Verifica:
+
+- Il filtro dell'elenco dei giochi non è impostato su "Nascondi giochi senza elementi scambiabili"
+- Una libreria di giochi specifica è abilitata nelle impostazioni
+
+Se hai verificato queste opzioni e il tuo gioco continua a non essere visualizzato, potrebbe esserci un bug. Ti saremmo grati se segnalassi il problema sul nostro repository GitHub, così potremo risolvere il problema e migliorare il rilevamento dei tuoi giochi in futuro.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_NoteTitle" xml:space="preserve">
+    <value>Nota per l'aggiunta manuale di giochi</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_PathExistsTemplate" xml:space="preserve">
+    <value>Il percorso di installazione "{0}" esiste già e non può essere aggiunto di nuovo.</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_SelectGameFolder" xml:space="preserve">
+    <value>Seleziona cartella di gioco</value>
+  </data>
+  <data name="GamesPage_ManuallyAdding_TopLevelDirectoryNotSupported" xml:space="preserve">
+    <value>L'aggiunta di una directory di primo livello non è supportata. Aggiungi la radice della directory di gioco.</value>
+  </data>
+  <data name="GamesPage_NewDlls" xml:space="preserve">
+    <value>Nuove DLL</value>
+  </data>
+  <data name="GamesPage_NewDllsFound" xml:space="preserve">
+    <value>Nuove DLL trovate</value>
+  </data>
+  <data name="GamesPage_NewDlls_CreateNewGitHubIssue" xml:space="preserve">
+    <value>Crea un nuovo problema su GitHub</value>
+  </data>
+  <data name="GamesPage_NewDlls_DiscoveredHelpUs" xml:space="preserve">
+    <value>Durante il caricamento dei giochi sono state scoperte alcune nuove DLL che non sono presenti nel manifesto DLSS Swapper.</value>
+  </data>
+  <data name="GamesPage_NewDlls_GitHubAccountRequired" xml:space="preserve">
+    <value>(È richiesto un account GitHub)</value>
+  </data>
+  <data name="GamesPage_NewDlls_IfButtonDoesntWorkTryHere" xml:space="preserve">
+    <value>Se il pulsante non funziona, prova qui,</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepFourSubmitYourIssue" xml:space="preserve">
+    <value>Passaggio 4: invia il tuo problema</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepOneCreateNewIssue" xml:space="preserve">
+    <value>Passaggio 1: crea un nuovo problema</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepThreeCopyBody" xml:space="preserve">
+    <value>Passaggio 3: copia il corpo</value>
+  </data>
+  <data name="GamesPage_NewDlls_StepTwoCopyTitle" xml:space="preserve">
+    <value>Passaggio 2: copia il titolo</value>
+  </data>
+  <data name="GamesPage_NewDlls_ThanksForHelping" xml:space="preserve">
+    <value>Grazie per l'aiuto!</value>
+  </data>
+  <data name="GamesPage_NewDlls_YouDoNotHaveToSubmitDllAutoTrack" xml:space="preserve">
+    <value>Non è necessario inviare le DLL. Le rintracceremo in base alle informazioni fornite.</value>
+  </data>
+  <data name="GamesPage_Title" xml:space="preserve">
+    <value>Giochi</value>
+  </data>
+  <data name="GamesPage_ViewType" xml:space="preserve">
+    <value>Visualizzazione</value>
+  </data>
+  <data name="GamesPage_ViewType_GridView" xml:space="preserve">
+    <value>Griglia</value>
+  </data>
+  <data name="GamesPage_ViewType_ListView" xml:space="preserve">
+    <value>Elenco</value>
+  </data>
+  <data name="Game_AreYouSureRemoveCustomCover" xml:space="preserve">
+    <value>Vuoi davvero rimuovere l'immagine di copertina personalizzata?</value>
+  </data>
+  <data name="Game_CurrentlyProcessing" xml:space="preserve">
+    <value>Gioco in fase di elaborazione</value>
+  </data>
+  <data name="Game_CustomCoverRemove" xml:space="preserve">
+    <value>Vuoi rimuovere la copertina personalizzata?</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeCatalog" xml:space="preserve">
+    <value>Impossibile deserializzare GOGCatalogResponse per l'URL, {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotDeserializeEmbedFilterResponse" xml:space="preserve">
+    <value>Impossibile deserializzare GOGEmbedFilteredResponse per l'URL {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyEmbedFilteredProducts" xml:space="preserve">
+    <value>Impossibile trovare GOGEmbedFilteredProducts per l'URL {0}</value>
+  </data>
+  <data name="Game_GOG_CouldNotFindAnyProduct" xml:space="preserve">
+    <value>Impossibile trovare alcun GOGCatalogProduct per l'URL {0}</value>
+  </data>
+  <data name="Game_UbisoftConnect_CouldNotDetectInstallKey" xml:space="preserve">
+    <value>Impossibile rilevare ubisoftConnectInstallsKey</value>
+  </data>
+  <data name="Game_UnknownGameLibraryTemplate" xml:space="preserve">
+    <value>GameLibrary {0} sconosciuta durante l'impostazione dell'ID</value>
+  </data>
+  <data name="General_ApplicationRunningAsAdmin" xml:space="preserve">
+    <value>Questa app è in esecuzione con privilegi amministrativi.</value>
+  </data>
+  <data name="General_Apply" xml:space="preserve">
+    <value>Applica</value>
+  </data>
+  <data name="General_Cancel" xml:space="preserve">
+    <value>Cancella</value>
+  </data>
+  <data name="General_Close" xml:space="preserve">
+    <value>Chiudi</value>
+  </data>
+  <data name="General_Copy" xml:space="preserve">
+    <value>Copia</value>
+  </data>
+  <data name="General_Delete" xml:space="preserve">
+    <value>Elimina</value>
+  </data>
+  <data name="General_DontShowAgain" xml:space="preserve">
+    <value>Non mostrare più</value>
+  </data>
+  <data name="General_Error" xml:space="preserve">
+    <value>Errore</value>
+  </data>
+  <data name="General_ErrorMessage" xml:space="preserve">
+    <value>Messaggio di errore</value>
+  </data>
+  <data name="General_Export" xml:space="preserve">
+    <value>Esporta</value>
+  </data>
+  <data name="General_ExportAll" xml:space="preserve">
+    <value>Esporta tutto</value>
+  </data>
+  <data name="General_Failed" xml:space="preserve">
+    <value>Fallito</value>
+  </data>
+  <data name="General_FeatureNotSupportedWhenAdmin" xml:space="preserve">
+    <value>Questa funzionalità non è supportata se si esegue l'applicazione come amministratore.</value>
+  </data>
+  <data name="General_Filter" xml:space="preserve">
+    <value>Filtro</value>
+  </data>
+  <data name="General_Help" xml:space="preserve">
+    <value>Aiuto</value>
+  </data>
+  <data name="General_Import" xml:space="preserve">
+    <value>Importare</value>
+  </data>
+  <data name="General_Load" xml:space="preserve">
+    <value>Carica</value>
+  </data>
+  <data name="General_Loading" xml:space="preserve">
+    <value>Caricamento</value>
+  </data>
+  <data name="General_Name" xml:space="preserve">
+    <value>Nome</value>
+  </data>
+  <data name="General_No" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="General_None" xml:space="preserve">
+    <value>Nessuno</value>
+  </data>
+  <data name="General_NotSupported" xml:space="preserve">
+    <value>Not supported</value>
+  </data>
+  <data name="General_Okay" xml:space="preserve">
+    <value>Va bene</value>
+  </data>
+  <data name="General_Oops" xml:space="preserve">
+    <value>Oops</value>
+  </data>
+  <data name="General_OpenFolder" xml:space="preserve">
+    <value>Apri cartella</value>
+  </data>
+  <data name="General_Optional" xml:space="preserve">
+    <value>(opzionale)</value>
+  </data>
+  <data name="General_Options" xml:space="preserve">
+    <value>Opzioni</value>
+  </data>
+  <data name="General_Publish" xml:space="preserve">
+    <value>Pubblica</value>
+  </data>
+  <data name="General_Refresh" xml:space="preserve">
+    <value>Aggiornare</value>
+  </data>
+  <data name="General_Reload" xml:space="preserve">
+    <value>Ricarica</value>
+  </data>
+  <data name="General_Remove" xml:space="preserve">
+    <value>Rimuovi</value>
+  </data>
+  <data name="General_ReportIssue" xml:space="preserve">
+    <value>Segnala un problema</value>
+  </data>
+  <data name="General_Save" xml:space="preserve">
+    <value>Salva</value>
+  </data>
+  <data name="General_Search" xml:space="preserve">
+    <value>Ricerca</value>
+  </data>
+  <data name="General_Sorry" xml:space="preserve">
+    <value>Scusa</value>
+  </data>
+  <data name="General_Success" xml:space="preserve">
+    <value>Successo</value>
+  </data>
+  <data name="General_Swap" xml:space="preserve">
+    <value>Scambio</value>
+  </data>
+  <data name="General_Unknown" xml:space="preserve">
+    <value>Sconosciuto</value>
+  </data>
+  <data name="General_Update" xml:space="preserve">
+    <value>Aggiornamento</value>
+  </data>
+  <data name="General_Version" xml:space="preserve">
+    <value>Versione</value>
+  </data>
+  <data name="General_Warning" xml:space="preserve">
+    <value>Avvertimento</value>
+  </data>
+  <data name="General_Yes" xml:space="preserve">
+    <value>SÌ</value>
+  </data>
+  <data name="GitHubUpdater_CouldNotLoadGitHubReleaseDataException" xml:space="preserve">
+    <value>Impossibile caricare i dati di rilascio di GitHub.</value>
+  </data>
+  <data name="GitHubUpdater_CurrentVersionIsActualTemplate" xml:space="preserve">
+    <value>Attualmente hai installato {0}.</value>
+  </data>
+  <data name="GitHubUpdater_DlssSwapperUpdated" xml:space="preserve">
+    <value>DLSS Swapper appena aggiornato</value>
+  </data>
+  <data name="GitHubUpdater_UpdateAvailable" xml:space="preserve">
+    <value>Aggiornamento disponibile</value>
+  </data>
+  <data name="LibraryPage_AlreadyDownloaded" xml:space="preserve">
+    <value>Già scaricato.</value>
+  </data>
+  <data name="LibraryPage_CouldNotLoadImportedDlls" xml:space="preserve">
+    <value>Impossibile caricare le DLL importate</value>
+  </data>
+  <data name="LibraryPage_CouldntDownload" xml:space="preserve">
+    <value>Al momento non è possibile effettuare il download.</value>
+  </data>
+  <data name="LibraryPage_CouldntExportDll" xml:space="preserve">
+    <value>Impossibile esportare le DLL.</value>
+  </data>
+  <data name="LibraryPage_DeleteDll" xml:space="preserve">
+    <value>Elimina DLL</value>
+  </data>
+  <data name="LibraryPage_DeleteDllVersionTemplate" xml:space="preserve">
+    <value>Eliminare {0} v{1}?</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_DownloadFileSize" xml:space="preserve">
+    <value>Scarica la dimensione del file</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileDescription" xml:space="preserve">
+    <value>Descrizione del file</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_FileSize" xml:space="preserve">
+    <value>Dimensione del file</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Hash" xml:space="preserve">
+    <value>Hash</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalName" xml:space="preserve">
+    <value>Nome interno</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_InternalNameExtra" xml:space="preserve">
+    <value>Nome interno Extra</value>
+  </data>
+  <data name="LibraryPage_DllRecordInfo_Label" xml:space="preserve">
+    <value>Etichetta</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Message" xml:space="preserve">
+    <value>Avviati {0} nuovi download.</value>
+  </data>
+  <data name="LibraryPage_DownloadsStarted_Title" xml:space="preserve">
+    <value>Download avviati</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLs" xml:space="preserve">
+    <value>DLL esportate:</value>
+  </data>
+  <data name="LibraryPage_ExportedDLLsCount_Message" xml:space="preserve">
+    <value>Esportate {0} DLL.</value>
+  </data>
+  <data name="LibraryPage_ExportedDllTemplate" xml:space="preserve">
+    <value>Esportata DLL {0}.</value>
+  </data>
+  <data name="LibraryPage_FileNotFound" xml:space="preserve">
+    <value>File non trovato.</value>
+  </data>
+  <data name="LibraryPage_Finished" xml:space="preserve">
+    <value>Finito</value>
+  </data>
+  <data name="LibraryPage_ImportedAsExistingRecord" xml:space="preserve">
+    <value>Importato come record DLL esistente.</value>
+  </data>
+  <data name="LibraryPage_Importing" xml:space="preserve">
+    <value>Importazione</value>
+  </data>
+  <data name="LibraryPage_MaliciousDllsInfo" xml:space="preserve">
+    <value>Sostituire le DLL sul computer può essere pericoloso.
+
+Inserire una DLL dannosa in un gioco è pericoloso quanto eseguire il file Linking_park_-_nUmB_mp3.exe appena scaricato da LimeWire.
+
+Importa le DLL solo da fonti affidabili.</value>
+  </data>
+  <data name="LibraryPage_NoDLLsForExport_Message" xml:space="preserve">
+    <value>Nessuna DLL trovata per l'esportazione.</value>
+  </data>
+  <data name="LibraryPage_NoDllsToExport" xml:space="preserve">
+    <value>Non hai record DLL da esportare.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Message" xml:space="preserve">
+    <value>Non c'erano nuove DLL da scaricare.</value>
+  </data>
+  <data name="LibraryPage_NoNewDLLs_Title" xml:space="preserve">
+    <value>Nessuna nuova DLL</value>
+  </data>
+  <data name="LibraryPage_ProcessedDlls" xml:space="preserve">
+    <value>DLL elaborate:</value>
+  </data>
+  <data name="LibraryPage_Title" xml:space="preserve">
+    <value>Biblioteca</value>
+  </data>
+  <data name="LibraryPage_UnableToDeleteRecord" xml:space="preserve">
+    <value>Impossibile eliminare il record {0}.</value>
+  </data>
+  <data name="LibraryPage_UnableToUpdateDllRecord" xml:space="preserve">
+    <value>Impossibile aggiornare i record DLL.</value>
+  </data>
+  <data name="LibraryPage_ZipDidNotContainAnyDlls" xml:space="preserve">
+    <value>Zip non conteneva alcun file dll.</value>
+  </data>
+  <data name="MainWindow_AttemptingManifestUpdate" xml:space="preserve">
+    <value>Tentativo di aggiornamento</value>
+  </data>
+  <data name="MainWindow_DlssSwapperCloseDueToManifest" xml:space="preserve">
+    <value>DLSS Swapper non è riuscito a caricare il suo file manifesto. Verrà chiuso.</value>
+  </data>
+  <data name="MainWindow_DlssSwapperMustClose" xml:space="preserve">
+    <value>DLSS Swapper deve essere chiuso</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_GitHubIssues" xml:space="preserve">
+    <value>Problemi di GitHub</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_Message" xml:space="preserve">
+    <value>Non siamo riusciti a caricare manifest.json dal tuo computer o da internet.
+
+Se il problema persiste, invia una segnalazione tramite il nostro issue tracker su GitHub.</value>
+  </data>
+  <data name="MainWindow_ManifestCouldNotBeLoaded_UpdateManifest" xml:space="preserve">
+    <value>Aggiorna manifesto</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Message" xml:space="preserve">
+    <value>Sebbene cambiare la versione DLSS non sia considerato un imbroglio, alcuni sistemi anti-cheat potrebbero non essere d'accordo se i file nella directory del gioco non corrispondono a quelli con cui è stato distribuito.
+
+Per questo motivo, consigliamo di usare cautela nelle partite multigiocatore.</value>
+  </data>
+  <data name="MainWindow_NoteForMultiplayerGames_Title" xml:space="preserve">
+    <value>Nota per i giochi multigiocatore</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterStillDoesNotWork" xml:space="preserve">
+    <value>Ancora non funziona</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTesterWorks" xml:space="preserve">
+    <value>Funziona!</value>
+  </data>
+  <data name="NetworkTesterPage_BrowserTestTitle" xml:space="preserve">
+    <value>Test del browser</value>
+  </data>
+  <data name="NetworkTesterPage_CancelCurrentTest" xml:space="preserve">
+    <value>Annulla il test corrente</value>
+  </data>
+  <data name="NetworkTesterPage_CopyTestResults" xml:space="preserve">
+    <value>Copia i risultati del test</value>
+  </data>
+  <data name="NetworkTesterPage_CreateBugReport" xml:space="preserve">
+    <value>Crea segnalazione bug</value>
+  </data>
+  <data name="NetworkTesterPage_CustomUserAgentTest" xml:space="preserve">
+    <value>Test dell'agente utente personalizzato</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest10Title" xml:space="preserve">
+    <value>Scaricamento della DLL del DLSS Swapper all'interno di DLSS Swapper con agente utente personalizzato</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest11Title" xml:space="preserve">
+    <value>Scaricamento della DLL del DLSS dallo specchio di UploadThing</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest1Title" xml:space="preserve">
+    <value>Accesso a google.com da DLSS Swapper (verifica la connettività Internet generale)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest2Title" xml:space="preserve">
+    <value>Accesso a bing.com da DLSS Swapper (verifica la connettività Internet generale)</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest3Title" xml:space="preserve">
+    <value>Scaricamento della DLL DLSS Swapper all'interno di DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest4Title" xml:space="preserve">
+    <value>Scaricamento della DLL DLSS Swapper dal browser</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest5Title" xml:space="preserve">
+    <value>Scaricamento della DLL DLSS Swapper dal browser</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest6Title" xml:space="preserve">
+    <value>Scaricare la copertina del gioco dall'Epic Game Store</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest7Title" xml:space="preserve">
+    <value>Scaricamento della copertina del gioco dal file server DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest8Title" xml:space="preserve">
+    <value>Scaricamento della copertina del gioco dal file server alternativo DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_DiagnosticsTest9Title" xml:space="preserve">
+    <value>Scaricamento della copertina del gioco dal file server alternativo DLSS Swapper</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowser" xml:space="preserve">
+    <value>Apri nel browser</value>
+  </data>
+  <data name="NetworkTesterPage_OpenInBrowserInfo" xml:space="preserve">
+    <value>Clicca sul pulsante "Apri nel browser" o copia e incolla il seguente link nel tuo browser. Scarica un file nel tuo browser?</value>
+  </data>
+  <data name="NetworkTesterPage_Results" xml:space="preserve">
+    <value>Risultati</value>
+  </data>
+  <data name="NetworkTesterPage_RunTest" xml:space="preserve">
+    <value>Esegui il test</value>
+  </data>
+  <data name="NetworkTesterPage_UseUserAgentInfo" xml:space="preserve">
+    <value>Utilizza l'agente utente fornito oppure inseriscine uno personalizzato a tua scelta.</value>
+  </data>
+  <data name="NetworkTesterPage_WindowTitle" xml:space="preserve">
+    <value>Tester di rete</value>
+  </data>
+  <data name="SettingsPage_About" xml:space="preserve">
+    <value>Informazioni</value>
+  </data>
+  <data name="SettingsPage_AddIgnoredPath" xml:space="preserve">
+    <value>Aggiungi percorso ignorato</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDlls" xml:space="preserve">
+    <value>Consenti DLL di debug</value>
+  </data>
+  <data name="SettingsPage_AllowDebugDllsInfo" xml:space="preserve">
+    <value>Talvolta gli SDK rilasciano DLL di debug che consentono di visualizzare ulteriori informazioni sullo schermo.</value>
+  </data>
+  <data name="SettingsPage_AllowUntrustedInfo" xml:space="preserve">
+    <value>Le DLL vengono controllate per verificarne l'affidabilità in Windows convalidandone la firma prima di essere spostate in una cartella di gioco. Se una DLL non supera la convalida della firma, non verrà utilizzata. Si consiglia di disattivare questa opzione.</value>
+  </data>
+  <data name="SettingsPage_AppliesOnlyToDllPickerNotLibrary" xml:space="preserve">
+    <value>This only applies to the DLL picker, not the library page.</value>
+  </data>
+  <data name="SettingsPage_CouldNotOpenLogFileTryManual" xml:space="preserve">
+    <value>Impossibile aprire il file di registro direttamente da DLSS Swapper. Prova ad aprirlo manualmente.</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathMessage" xml:space="preserve">
+    <value>Sei sicuro di voler eliminare il percorso ignorato {0}?</value>
+  </data>
+  <data name="SettingsPage_DeleteIgnoredPathTitle" xml:space="preserve">
+    <value>Elimina percorso ignorato</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions" xml:space="preserve">
+    <value>Opzioni per sviluppatori DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToConsoleWindow" xml:space="preserve">
+    <value>Abilita la registrazione nella finestra della console</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_EnableLoggingToFile" xml:space="preserve">
+    <value>Abilita la registrazione nel file</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForAllDlssDlls" xml:space="preserve">
+    <value>Abilitato per tutte le DLL di DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_IndicatorEnabledForDebugDlssDllOnly" xml:space="preserve">
+    <value>Abilitato solo per il debug delle DLL DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_ShowOnScreenIndicator" xml:space="preserve">
+    <value>Mostra indicatore sullo schermo</value>
+  </data>
+  <data name="SettingsPage_DLSSDeveloperOptions_VerboseLogging" xml:space="preserve">
+    <value>Registrazione dettagliata</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions" xml:space="preserve">
+    <value>Opzioni DLSS</value>
+  </data>
+  <data name="SettingsPage_DLSSOptions_GlobalPreset" xml:space="preserve">
+    <value>Preset globale</value>
+  </data>
+  <data name="SettingsPage_GameLibraries" xml:space="preserve">
+    <value>Librerie di giochi</value>
+  </data>
+  <data name="SettingsPage_GeneralTroubleshootingGuide" xml:space="preserve">
+    <value>Guida generale alla risoluzione dei problemi</value>
+  </data>
+  <data name="SettingsPage_GiveFeedback" xml:space="preserve">
+    <value>Fornisci feedback</value>
+  </data>
+  <data name="SettingsPage_GiveFeedbackInfo" xml:space="preserve">
+    <value>Puoi suggerire una funzionalità o segnalare un problema su DLSS Swapper</value>
+  </data>
+  <data name="SettingsPage_IgnoredPaths" xml:space="preserve">
+    <value>Percorsi ignorati</value>
+  </data>
+  <data name="SettingsPage_Language" xml:space="preserve">
+    <value>Lingua</value>
+  </data>
+  <data name="SettingsPage_LibraryDisabled" xml:space="preserve">
+    <value>{0} disabilitato</value>
+  </data>
+  <data name="SettingsPage_LibraryEnabled" xml:space="preserve">
+    <value>{0} enabled</value>
+  </data>
+  <data name="SettingsPage_Logging" xml:space="preserve">
+    <value>Registrazione</value>
+  </data>
+  <data name="SettingsPage_NoNewUpdatesAvailable" xml:space="preserve">
+    <value>Non sono disponibili nuovi aggiornamenti.</value>
+  </data>
+  <data name="SettingsPage_OpenAcknowledgements" xml:space="preserve">
+    <value>Ringraziamenti</value>
+  </data>
+  <data name="SettingsPage_OpenDiagnostics" xml:space="preserve">
+    <value>Diagnostica</value>
+  </data>
+  <data name="SettingsPage_OpenNetworkTester" xml:space="preserve">
+    <value>Tester di rete</value>
+  </data>
+  <data name="SettingsPage_OpenTranslationToolbox" xml:space="preserve">
+    <value>Open translation toolbox</value>
+  </data>
+  <data name="SettingsPage_PathAlreadyIgnored" xml:space="preserve">
+    <value>Il percorso {0} è già stato ignorato.</value>
+  </data>
+  <data name="SettingsPage_SettingsAllowUntrusted" xml:space="preserve">
+    <value>Consenti non attendibile</value>
+  </data>
+  <data name="SettingsPage_SettingsCheckForUpdates" xml:space="preserve">
+    <value>Controlla gli aggiornamenti</value>
+  </data>
+  <data name="SettingsPage_ShowOnlyDownloadedDlls" xml:space="preserve">
+    <value>Mostra solo le DLL scaricate</value>
+  </data>
+  <data name="SettingsPage_ThemeDark" xml:space="preserve">
+    <value>Scuro</value>
+  </data>
+  <data name="SettingsPage_ThemeLight" xml:space="preserve">
+    <value>Chiaro</value>
+  </data>
+  <data name="SettingsPage_ThemeMode" xml:space="preserve">
+    <value>Tema</value>
+  </data>
+  <data name="SettingsPage_ThemeSystemSettingDefault" xml:space="preserve">
+    <value>Utilizzare le impostazioni di sistema</value>
+  </data>
+  <data name="SettingsPage_Title" xml:space="preserve">
+    <value>Impostazioni</value>
+  </data>
+  <data name="SettingsPage_Troubleshooting" xml:space="preserve">
+    <value>Risoluzione dei problemi</value>
+  </data>
+  <data name="SettingsPage_YourCurrentLogFile" xml:space="preserve">
+    <value>Il tuo file di registro corrente è </value>
+  </data>
+  <data name="TranslationToolboxPage_AdminError" xml:space="preserve">
+    <value>Non è possibile utilizzare lo strumento di traduzione mentre è in esecuzione come amministratore. Riavviare l'applicazione.</value>
+  </data>
+  <data name="TranslationToolboxPage_Comment" xml:space="preserve">
+    <value>Commento</value>
+  </data>
+  <data name="TranslationToolboxPage_ImportAsTranslation" xml:space="preserve">
+    <value>Importa lingua come traduzione</value>
+  </data>
+  <data name="TranslationToolboxPage_Key" xml:space="preserve">
+    <value>Chiave</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadExistingTranslation" xml:space="preserve">
+    <value>Carica esistente</value>
+  </data>
+  <data name="TranslationToolboxPage_LoadFailedMessage" xml:space="preserve">
+    <value>Carica esistente</value>
+  </data>
+  <data name="TranslationToolboxPage_NewTranslation" xml:space="preserve">
+    <value>Nuova traduzione</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToPublish" xml:space="preserve">
+    <value>Non sono stati trovati dati di traduzione da pubblicare.</value>
+  </data>
+  <data name="TranslationToolboxPage_NoDataToSave" xml:space="preserve">
+    <value>Non sono stati trovati dati di traduzione da salvare.</value>
+  </data>
+  <data name="TranslationToolboxPage_NotValidTranslationFile" xml:space="preserve">
+    <value>Non è un file di traduzione DLSS Swapper valido.</value>
+  </data>
+  <data name="TranslationToolboxPage_PublishFailedMessage" xml:space="preserve">
+    <value>Impossibile pubblicare la traduzione. Per ulteriori informazioni, consultare il registro degli errori.</value>
+  </data>
+  <data name="TranslationToolboxPage_ReloadApp" xml:space="preserve">
+    <value>Ricarica l'app</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressButton" xml:space="preserve">
+    <value>Reimposta e continua</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressMessage" xml:space="preserve">
+    <value>Questo azzererà l'attuale stato di avanzamento della traduzione. Vuoi continuare?</value>
+  </data>
+  <data name="TranslationToolboxPage_ResetProgressTitle" xml:space="preserve">
+    <value>Azzerare i progressi e continuare?</value>
+  </data>
+  <data name="TranslationToolboxPage_SaveFailedMessage" xml:space="preserve">
+    <value>Impossibile salvare la traduzione. Per ulteriori informazioni, consultare il registro degli errori.</value>
+  </data>
+  <data name="TranslationToolboxPage_SelectLanguageToLoad" xml:space="preserve">
+    <value>Seleziona la lingua da caricare</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceLanguage" xml:space="preserve">
+    <value>Lingua di origine</value>
+  </data>
+  <data name="TranslationToolboxPage_SourceTranslation" xml:space="preserve">
+    <value>Traduzione della fonte</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideButton" xml:space="preserve">
+    <value>Guida alla traduzione</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationGuideMessage" xml:space="preserve">
+    <value>La tua traduzione è stata creata. Consulta la guida alla traduzione di DLSS Swapper per sapere come procedere con {0}.</value>
+  </data>
+  <data name="TranslationToolboxPage_TranslationProgress" xml:space="preserve">
+    <value>Progresso della traduzione</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesButton" xml:space="preserve">
+    <value>Chiudi senza salvare</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesMessage" xml:space="preserve">
+    <value>Potresti avere modifiche alla traduzione non salvate. Se chiudi questa finestra, queste andranno perse.</value>
+  </data>
+  <data name="TranslationToolboxPage_UnsavedChangesTitle" xml:space="preserve">
+    <value>Modifiche alla traduzione non salvate</value>
+  </data>
+  <data name="TranslationToolboxPage_WindowTitle" xml:space="preserve">
+    <value>Strumenti di traduzione</value>
+  </data>
+</root>


### PR DESCRIPTION
## Description of Changes

Added 'it-IT' to the supported languages in LanguageManager and included the Italian translation resource file Resources.resw. This enables Italian as a selectable language in settings.

<img width="2560" height="1392" alt="DLSS Swapper 19_7_2025 17_39_35" src="https://github.com/user-attachments/assets/d85b1f70-c29d-4048-82e0-a43887e4f06c" />

It has been tested and should work well.

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [ ] Bug fix
- [X] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
