### PR TITLE
Update Catalan translations to imperative verb form and missing translations

### DIFF
--- a/src/Translations/ca-ES/Resources.resw
+++ b/src/Translations/ca-ES/Resources.resw
@@ -154,7 +154,7 @@
     <value>No s'ha pogut descarregar el fitxer.</value>
   </data>
   <data name="DllRecord_Download" xml:space="preserve">
-    <value>Descarregar</value>
+    <value>Descarrega</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Error de descàrrega</value>
@@ -178,13 +178,13 @@
     <value>No s'ha pogut iniciar DLSS Swapper</value>
   </data>
   <data name="FailedToLaunchPage_PleaseOpenIssuePartial1" xml:space="preserve">
-    <value>Si us plau, obriu un</value>
+    <value>Si us plau, obriu un </value>
   </data>
   <data name="FailedToLaunchPage_PleaseOpenIssuePartial2" xml:space="preserve">
     <value>nou error</value>
   </data>
   <data name="FailedToLaunchPage_PleaseOpenIssuePartial3" xml:space="preserve">
-    <value>al repositori de GitHub de DLSS Swapper i proporciona la següent informació a la secció de context addicional.</value>
+    <value> al repositori de GitHub de DLSS Swapper i proporciona la següent informació a la secció de context addicional.</value>
   </data>
   <data name="FailedToLaunchPage_WindowTitle" xml:space="preserve">
     <value>No s'ha pogut iniciar</value>
@@ -278,7 +278,7 @@ Per verificar quin preset s'està utilitzant, activeu l'indicador de DLSS en pan
     <value>"{0}" és un tipus de fitxer no vàlid</value>
   </data>
   <data name="GamePage_Launch" xml:space="preserve">
-    <value>Iniciar</value>
+    <value>Inicia</value>
   </data>
   <data name="GamePage_ManuallyAdded_CantBeRemoved" xml:space="preserve">
     <value>Aquest títol no ha sigut afegit manualment i no es pot eliminar.</value>
@@ -332,7 +332,7 @@ Per verificar quin preset s'està utilitzant, activeu l'indicador de DLSS en pan
     <value>Només podeu arrossegar un sol fitxer per a una portada</value>
   </data>
   <data name="GamesPage_AddGame" xml:space="preserve">
-    <value>Afegir joc</value>
+    <value>Afegeix un joc</value>
   </data>
   <data name="GamesPage_GroupGamesFromTheSameLibraryTogether" xml:space="preserve">
     <value>Agrupa jocs de la mateixa biblioteca junts</value>
@@ -457,22 +457,22 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Aquesta aplicació s'està executant amb privilegis d'administrador.</value>
   </data>
   <data name="General_Apply" xml:space="preserve">
-    <value>Aplicar</value>
+    <value>Aplica</value>
   </data>
   <data name="General_Cancel" xml:space="preserve">
-    <value>Cancel·lar</value>
+    <value>Cancel·la</value>
   </data>
   <data name="General_Close" xml:space="preserve">
-    <value>Tancar</value>
+    <value>Tanca</value>
   </data>
   <data name="General_Copy" xml:space="preserve">
-    <value>Copiar</value>
+    <value>Copia</value>
   </data>
   <data name="General_Delete" xml:space="preserve">
-    <value>Suprimir</value>
+    <value>Suprimeix</value>
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
-    <value>No tornar a mostrar</value>
+    <value>No tornis a mostrar</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Error</value>
@@ -481,7 +481,7 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Missatge d'error</value>
   </data>
   <data name="General_Export" xml:space="preserve">
-    <value>Exportar</value>
+    <value>Exporta</value>
   </data>
   <data name="General_ExportAll" xml:space="preserve">
     <value>Exportat tot</value>
@@ -499,10 +499,10 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Ajuda</value>
   </data>
   <data name="General_Import" xml:space="preserve">
-    <value>Importar</value>
+    <value>Importa</value>
   </data>
   <data name="General_Load" xml:space="preserve">
-    <value>Carregar</value>
+    <value>Carrega</value>
   </data>
   <data name="General_Loading" xml:space="preserve">
     <value>Carregant</value>
@@ -526,7 +526,7 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Ups</value>
   </data>
   <data name="General_OpenFolder" xml:space="preserve">
-    <value>Obrir carpeta</value>
+    <value>Obre la carpeta</value>
   </data>
   <data name="General_Optional" xml:space="preserve">
     <value>(opcional)</value>
@@ -535,40 +535,40 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Opcions</value>
   </data>
   <data name="General_Publish" xml:space="preserve">
-    <value>Publicar</value>
+    <value>Publica</value>
   </data>
   <data name="General_Refresh" xml:space="preserve">
-    <value>Actualizar</value>
+    <value>Actualitzar</value>
   </data>
   <data name="General_Reload" xml:space="preserve">
-    <value>Tornar a carregar</value>
+    <value>Torna a carregar</value>
   </data>
   <data name="General_Remove" xml:space="preserve">
-    <value>Eliminar</value>
+    <value>Elimina</value>
   </data>
   <data name="General_ReportIssue" xml:space="preserve">
     <value>Informar d'un problema</value>
   </data>
   <data name="General_Save" xml:space="preserve">
-    <value>Desar</value>
+    <value>Desa</value>
   </data>
   <data name="General_Search" xml:space="preserve">
-    <value>Cercar</value>
+    <value>Cerca</value>
   </data>
   <data name="General_Sorry" xml:space="preserve">
     <value>Perdó</value>
   </data>
   <data name="General_Success" xml:space="preserve">
-    <value>Êxit</value>
+    <value>Èxit</value>
   </data>
   <data name="General_Swap" xml:space="preserve">
-    <value>Intercanviar</value>
+    <value>Intercanvia</value>
   </data>
   <data name="General_Unknown" xml:space="preserve">
     <value>Desconegut</value>
   </data>
   <data name="General_Update" xml:space="preserve">
-    <value>Actualització</value>
+    <value>Actualitza</value>
   </data>
   <data name="General_Version" xml:space="preserve">
     <value>Versió</value>
@@ -631,7 +631,7 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>Etiqueta</value>
   </data>
   <data name="LibraryPage_DownloadsStarted_Message" xml:space="preserve">
-    <value>Started {0} new downloads.</value>
+    <value>S'han iniciat {0} noves descàrregues.</value>
   </data>
   <data name="LibraryPage_DownloadsStarted_Title" xml:space="preserve">
     <value>Descàrregues iniciades</value>
@@ -649,7 +649,7 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>No s'ha trobat el fitxer.</value>
   </data>
   <data name="LibraryPage_Finished" xml:space="preserve">
-    <value>Acabat</value>
+    <value>Finalitzat</value>
   </data>
   <data name="LibraryPage_ImportedAsExistingRecord" xml:space="preserve">
     <value>Importat com a registre DLL existent.</value>
@@ -729,10 +729,10 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Prova del navegador</value>
   </data>
   <data name="NetworkTesterPage_CancelCurrentTest" xml:space="preserve">
-    <value>Cancel·lar la prova actual</value>
+    <value>Cancel·la la prova actual</value>
   </data>
   <data name="NetworkTesterPage_CopyTestResults" xml:space="preserve">
-    <value>Copiar els resultats de la prova</value>
+    <value>Copia els resultats de la prova</value>
   </data>
   <data name="NetworkTesterPage_CreateBugReport" xml:space="preserve">
     <value>Crea un informe d'errors</value>
@@ -765,7 +765,7 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Descarregant la portada del joc de l'Epic Game Store</value>
   </data>
   <data name="NetworkTesterPage_DiagnosticsTest7Title" xml:space="preserve">
-    <value>Downloading game cover from DLSS Swapper file server</value>
+    <value>Descarregant la portada del joc des del servidor de fitxers DLSS Swapper</value>
   </data>
   <data name="NetworkTesterPage_DiagnosticsTest8Title" xml:space="preserve">
     <value>Descarregant la portada del joc des d'un servidor de fitxers DLSS Swapper alternatiu</value>
@@ -774,7 +774,7 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Cerca DNS del servidor de fitxers DLSS Swapper</value>
   </data>
   <data name="NetworkTesterPage_OpenInBrowser" xml:space="preserve">
-    <value>Obrir al navegador</value>
+    <value>Obre al navegador</value>
   </data>
   <data name="NetworkTesterPage_OpenInBrowserInfo" xml:space="preserve">
     <value>Feu clic al botó obrir al navegador o copieu i enganxeu l'enllaç següent al vostre navegador. Es descarrega algun fitxer al vostre navegador?</value>
@@ -783,7 +783,7 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Resultats</value>
   </data>
   <data name="NetworkTesterPage_RunTest" xml:space="preserve">
-    <value>Executar la prova</value>
+    <value>Executa la prova</value>
   </data>
   <data name="NetworkTesterPage_UseUserAgentInfo" xml:space="preserve">
     <value>Feu servir l'agent d'usuari proporcionat o introduïu-ne un de personalitzat que trieu.</value>
@@ -798,7 +798,7 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Afegeix una ruta ignorada</value>
   </data>
   <data name="SettingsPage_AllowDebugDlls" xml:space="preserve">
-    <value>Permetre DLL de depuració</value>
+    <value>Permet DLL de depuració</value>
   </data>
   <data name="SettingsPage_AllowDebugDllsInfo" xml:space="preserve">
     <value>Els SDK de vegades publiquen DLL de depuració que permeten mostrar informació addicional en pantalla.</value>
@@ -957,7 +957,7 @@ Per això, recomanem anar amb compte amb les partides multijugador.</value>
     <value>Torna a carregar l'aplicació</value>
   </data>
   <data name="TranslationToolboxPage_ResetProgressButton" xml:space="preserve">
-    <value>Restablir i continuar</value>
+    <value>Restableix i continua</value>
   </data>
   <data name="TranslationToolboxPage_ResetProgressMessage" xml:space="preserve">
     <value>Això restablirà el progrés actual de la traducció. Esteu segur que voleu continuar?</value>


### PR DESCRIPTION
## Description of Changes

Revised multiple Catalan UI strings to use consistent verb forms and improved phrasing. This enhances clarity and aligns with standard Catalan localization practices. Basically, the verb forms have been changed to imperative. I also added some missing translations.

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
