### PR TITLE
Replace dot with middle dot in language selectors

### DIFF
--- a/readmes/readme_ca.md
+++ b/readmes/readme_ca.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     Català
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readmes/readme_es.md">Español</a>

--- a/readmes/readme_es.md
+++ b/readmes/readme_es.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     Español

--- a/readmes/readme_ja-JP.md
+++ b/readmes/readme_ja-JP.md
@@ -17,7 +17,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readme_es.md">Español</a>

--- a/readmes/readme_pt-BR.md
+++ b/readmes/readme_pt-BR.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readme_es.md">Español</a>

--- a/readmes/readme_tr-TR.md
+++ b/readmes/readme_tr-TR.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readme_es.md">Español</a>

--- a/readmes/readme_zh-Hans.md
+++ b/readmes/readme_zh-Hans.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readme_es.md">Español</a>

--- a/readmes/readme_zh-TW.md
+++ b/readmes/readme_zh-TW.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     <a href="../README.md">English</a>    
     ·
     <a href="./readme_es.md">Español</a>


### PR DESCRIPTION
## Description of Changes

Updated the language selection navigation in multiple localized README files to use the middle dot (·) instead of a period (.) as a separator for improved visual consistency.

<!-- If applicable, include images or screenshots to illustrate the changes made. -->

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
