### PR TITLE
Fix separator character in language links

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 
 <p align="center">
     <a href="./readmes/readme_ca.md">Català</a>
-    .
+    ·
     English
     ·
     <a href="./readmes/readme_es.md">Español</a>


### PR DESCRIPTION
## Description of Changes

Replaced the period separator with a middle dot for consistency in the language selection links in the README. I did it with the other readmes in the pull request #630 but I forgot to fix the original english readme too.

## Type of Change

<!-- Uncomment the line below that corresponds to the type of change made in the PR. -->
<!-- Mark the appropriate option with an 'x'. -->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update

## Issues Resolved

<!-- If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed. -->

<!-- Example:
#123
#345
-->
