### PR TITLE
Simplify language names in LanguageManager

### DIFF
--- a/src/Helpers/LanguageManager.cs
+++ b/src/Helpers/LanguageManager.cs
@@ -72,13 +72,13 @@ public class LanguageManager
             "ar-SA" => "اللغة العربية (المملكة العربية السعودية)", // Arabic (Saudi Arabia)
             "ar-SY" => " (سوريا) العربية", // Arabic (Syria)
             "ca-ES" => "Català", // Catalan
-            "de-DE" => "Deutsch (Deutschland)", // German (Germany)
+            "de-DE" => "Deutsch", // German (Germany)
             "en-AU" => "English (Australia)",
             "en-GB" => "English (United Kingdom)",
             "en-US" => "English (United States)",
             "es-ES" => "Español", // Spanish
-            "fr-FR" => "Français (France)", // French (France)
-            "it-IT" => "Italiano (Italia)", // Italian (Italy)
+            "fr-FR" => "Français", // French (France)
+            "it-IT" => "Italiano", // Italian (Italy)
             "pl-PL" => "Polski", // Polish
             "pt-BR" => "Português BR",
             "ru-RU" => "Русский", // Russian


### PR DESCRIPTION
## Description of Changes

I removed country-specific qualifiers from some language names (like German, French, and Italian) to make the language list more consistent.

Some languages (like Catalan, Spanish, Polish, or Russian) were already displayed without region tags, while others (like "German (Germany)") had them, even though only one version exists in the app. This inconsistency looked a bit odd and unnecessary.

I kept region tags only for languages that have clearly different regional variants that are used in the app (like Portuguese from Brazil, or English from the US, UK, and Australia). These need to be distinguished, but for the rest, just using the language name is cleaner and more consistent.

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Translation update

## Issues Resolved

<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
