### PR TITLE
Fixes an issue where "download latest" would not get latest FSR version

### DIFF
--- a/src/Data/DLLRecord.cs
+++ b/src/Data/DLLRecord.cs
@@ -134,6 +134,32 @@ public class DLLRecord : IComparable<DLLRecord>, INotifyPropertyChanged
         }
     }
 
+    Version? _displayVersionVersion;
+    [JsonIgnore]
+    public Version DisplayVersionVersion
+    {
+        get
+        {
+            if (_displayVersionVersion is not null)
+            {
+                return _displayVersionVersion;
+            }
+
+            try
+            {
+                var version = new Version(DisplayVersion);
+                _displayVersionVersion = version;
+                return version;
+            }
+            catch (Exception err)
+            {
+                Logger.Error(err, $"Failed to parse display version ({DisplayVersion}) into a Version object.");
+                return new Version(0, 0, 0, 0);
+            }
+        }
+    }
+
+
     /// <summary>
     /// Returns the display version (eg 2.5.0.0 slimmed down to 2.5) and prefixes with v, and suffix with additional label if it exists.
     /// </summary>

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -1038,11 +1038,27 @@ public partial class LibraryPageModel : ObservableObject
                 {
                     latestRecord = record;
                 }
-                else if (record.VersionNumber > latestRecord.VersionNumber)
+                else
                 {
-                    latestRecord = record;
+                    if (record.AssetType == GameAssetType.FSR_31_DX12 ||
+                        record.AssetType == GameAssetType.FSR_31_VK ||
+                        record.AssetType == GameAssetType.FSR_31_DX12_BACKUP ||
+                        record.AssetType == GameAssetType.FSR_31_VK_BACKUP)
+                    {
+                        if (record.DisplayVersionVersion > latestRecord.DisplayVersionVersion)
+                        {
+                            latestRecord = record;
+                        }
+                    }
+                    else
+                    {
+                        if (record.VersionNumber > latestRecord.VersionNumber)
+                        {
+                            latestRecord = record;
+                        }
+                    }
                 }
-            }           
+            }
         }
 
         return latestRecord;


### PR DESCRIPTION
## Description of Changes

Because FSR is ordered poorly the "download latest" will attempt to download the latest product version which is v1.0.2 (FSR 3.1.2) however the latest is v1.0.1 (FSR 3.1.4).

<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

https://x.com/Aethellotric/status/1952165810857796050
<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
