### PR TITLE
Added fallback to getting Steam covers via IStoreBrowseService

### DIFF
--- a/src/Data/Game.cs
+++ b/src/Data/Game.cs
@@ -1019,19 +1019,19 @@ namespace DLSS_Swapper.Data
             }
         }
 
-        protected async Task DownloadCoverAsync(string url)
+        protected async Task<bool> DownloadCoverAsync(string url)
         {
             if (string.IsNullOrEmpty(url))
             {
                 Logger.Error($"Tried to download cover image but url was null or empty. Game: {Title}, Library: {GameLibrary}");
-                return;
+                return false;
             }
 
             if (url.StartsWith("http://", StringComparison.OrdinalIgnoreCase) == false &&
                 url.StartsWith("https://", StringComparison.OrdinalIgnoreCase) == false)
             {
                 Logger.Error($"Tried to download cover image but url was not valid. Game: {Title}, Library: {GameLibrary}, Url: {url}");
-                return;
+                return false;
             }
 
 
@@ -1056,11 +1056,13 @@ namespace DLSS_Swapper.Data
                     // Now if the image is downloaded lets resize it,
                     await ResizeCoverAsync(memoryStream).ConfigureAwait(false);
                 }
+                return true;
             }
             catch (Exception err)
             {
                 Logger.Error(err, $"For url: {url}");
                 //Debugger.Break();
+                return false;
             }
             finally
             {

--- a/src/Data/Steam/SteamAPI/GetItemsInput.cs
+++ b/src/Data/Steam/SteamAPI/GetItemsInput.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+internal class GetItemsInput
+{
+    [JsonPropertyName("ids")]
+    public List<StoreItemId> Ids { get; set; } = new List<StoreItemId>();
+
+    [JsonPropertyName("context")]
+    public StoreBrowseContext Context { get; set; } = new StoreBrowseContext();
+
+    [JsonPropertyName("data_request")]
+    public StoreBrowseItemDataRequest DataRequest { get; set; } = new StoreBrowseItemDataRequest();
+}

--- a/src/Data/Steam/SteamAPI/GetItemsResponse.cs
+++ b/src/Data/Steam/SteamAPI/GetItemsResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class GetItemsResponse
+{
+    [JsonPropertyName("store_items")]
+    public List<SteamStoreItem> StoreItems { get; set; } = new List<SteamStoreItem>();
+}

--- a/src/Data/Steam/SteamAPI/SteamAPIResponse.cs
+++ b/src/Data/Steam/SteamAPI/SteamAPIResponse.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class SteamAPIResponse<T>
+{
+    [JsonPropertyName("response")]
+    public T? Response { get; set; }
+}

--- a/src/Data/Steam/SteamAPI/SteamStoreItem.cs
+++ b/src/Data/Steam/SteamAPI/SteamStoreItem.cs
@@ -1,0 +1,46 @@
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class SteamStoreItem
+{
+    /*
+    [JsonPropertyName("item_type")]
+    public int ItemType { get; set; }
+    */
+
+    [JsonPropertyName("id")]
+    public int Id { get; set; }
+
+    [JsonPropertyName("success")]
+    public int Success { get; set; }
+
+    /*
+    [JsonPropertyName("visible")]
+    public bool Visible { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [JsonPropertyName("store_url_path")]
+    public string StoreUrlPath { get; set; } = string.Empty;
+    */
+
+    [JsonPropertyName("appid")]
+    public int AppId { get; set; }
+
+    /*
+    [JsonPropertyName("type")]
+    public int Type { get; set; }
+
+    [JsonPropertyName("related_items")]
+    public SteamStoreItemRelatedItems RelatedItems { get; set; }
+
+    [JsonPropertyName("categories")]
+    public SteamStoreItemCategories Categories { get; set; }
+    */
+
+    [JsonPropertyName("assets")]
+    public SteamStoreItemAssets? Assets { get; set; }
+
+}

--- a/src/Data/Steam/SteamAPI/SteamStoreItemAssets.cs
+++ b/src/Data/Steam/SteamAPI/SteamStoreItemAssets.cs
@@ -1,0 +1,48 @@
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class SteamStoreItemAssets
+{
+    [JsonPropertyName("asset_url_format")]
+    public string AssetUrlFormat { get; set; } = string.Empty;
+
+    [JsonPropertyName("main_capsule")]
+    public string MainCapsule { get; set; } = string.Empty;
+
+    [JsonPropertyName("small_capsule")]
+    public string SmallCapsule { get; set; } = string.Empty;
+
+    [JsonPropertyName("header")]
+    public string Header { get; set; } = string.Empty;
+
+    [JsonPropertyName("page_background")]
+    public string PageBackground { get; set; } = string.Empty;
+
+    [JsonPropertyName("hero_capsule")]
+    public string HeroCapsule { get; set; } = string.Empty;
+
+    [JsonPropertyName("hero_capsule_2x")]
+    public string HeroCapsule2x { get; set; } = string.Empty;
+
+    [JsonPropertyName("library_capsule")]
+    public string LibraryCapsule { get; set; } = string.Empty;
+
+    [JsonPropertyName("library_capsule_2x")]
+    public string LibraryCapsule2x { get; set; } = string.Empty;
+
+    [JsonPropertyName("library_hero")]
+    public string LibraryHero { get; set; } = string.Empty;
+
+    [JsonPropertyName("library_hero_2x")]
+    public string LibraryHero2x { get; set; } = string.Empty;
+
+    [JsonPropertyName("community_icon")]
+    public string CommunityIcon { get; set; } = string.Empty;
+
+    [JsonPropertyName("page_background_path")]
+    public string PageBackgroundPath { get; set; } = string.Empty;
+
+    [JsonPropertyName("raw_page_background")]
+    public string RawPageBackground { get; set; } = string.Empty;
+}

--- a/src/Data/Steam/SteamAPI/SteamStoreItemCategories.cs
+++ b/src/Data/Steam/SteamAPI/SteamStoreItemCategories.cs
@@ -1,0 +1,6 @@
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class SteamStoreItemCategories
+{
+}

--- a/src/Data/Steam/SteamAPI/SteamStoreItemRelatedItems.cs
+++ b/src/Data/Steam/SteamAPI/SteamStoreItemRelatedItems.cs
@@ -1,0 +1,9 @@
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class SteamStoreItemRelatedItems
+{
+    [JsonPropertyName("parent_appid")]
+    public int ParentAppId { get; set; }
+}

--- a/src/Data/Steam/SteamAPI/StoreBrowseContext.cs
+++ b/src/Data/Steam/SteamAPI/StoreBrowseContext.cs
@@ -1,0 +1,23 @@
+
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class StoreBrowseContext
+{
+    /*
+    [JsonPropertyName("language")]
+    public string Language { get; set; } = string.Empty;
+
+    [JsonPropertyName("elanguage")]
+    public string ELanguage { get; set; } = string.Empty;
+    */
+
+    [JsonPropertyName("country_code")]
+    public string CountryCode { get; set; } = "US";
+
+    /*
+    [JsonPropertyName("steam_realm")]
+    public string SteamRealm { get; set; } = string.Empty;
+    */
+}

--- a/src/Data/Steam/SteamAPI/StoreBrowseItemDataRequest.cs
+++ b/src/Data/Steam/SteamAPI/StoreBrowseItemDataRequest.cs
@@ -1,0 +1,59 @@
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class StoreBrowseItemDataRequest
+{
+    [JsonPropertyName("include_assets")]
+    public bool IncludeAssets { get; set; }
+
+    /*
+    [JsonPropertyName("include_release")]
+    public bool IncludeRelease { get; set; }
+
+    [JsonPropertyName("include_platforms")]
+    public bool IncludePlatforms { get; set; }
+
+    [JsonPropertyName("include_all_purchase_options")]
+    public bool IncludeAllPurchaseOptions { get; set; }
+
+    [JsonPropertyName("include_screenshots")]
+    public bool IncludeScreenshots { get; set; }
+
+    [JsonPropertyName("include_trailers")]
+    public bool IncludeTrailers { get; set; }
+
+    [JsonPropertyName("include_ratings")]
+    public bool IncludeRatings { get; set; }
+
+    //[JsonPropertyName("include_tag_count")]
+    //public int IncludeTagCount { get; set; }
+
+    [JsonPropertyName("include_reviews")]
+    public bool IncludeReviews { get; set; }
+
+    [JsonPropertyName("include_basic_info")]
+    public bool IncludeBasicInfo { get; set; }
+
+    [JsonPropertyName("include_supported_languages")]
+    public bool IncludeSupportedLanguages { get; set; }
+
+    [JsonPropertyName("include_full_description")]
+    public bool IncludeFullDescription { get; set; }
+
+    [JsonPropertyName("include_included_items")]
+    public bool IncludeIncludedItems { get; set; }
+
+    //[JsonPropertyName("included_item_data_request")]
+    //public StoreBrowseItemDataRequest IncludedItemDataRequest { get; set; }
+
+    [JsonPropertyName("include_assets_without_overrides")]
+    public bool IncludeAssetsWithoutOverrides { get; set; }
+
+    [JsonPropertyName("apply_user_filters")]
+    public bool ApplyUserFilters { get; set; }
+
+    [JsonPropertyName("include_links")]
+    public bool IncludeLinks { get; set; }
+    */
+}

--- a/src/Data/Steam/SteamAPI/StoreItemId.cs
+++ b/src/Data/Steam/SteamAPI/StoreItemId.cs
@@ -1,0 +1,27 @@
+
+using System.Text.Json.Serialization;
+
+namespace DLSS_Swapper.Data.Steam.SteamAPI;
+
+internal class StoreItemId
+{
+    [JsonPropertyName("appid")]
+    public int AppId { get; set; }
+
+    /*
+    [JsonPropertyName("packageid")]
+    public int PackageId { get; set; }
+
+    [JsonPropertyName("bundleid")]
+    public int BundleId { get; set; }
+
+    [JsonPropertyName("tagid")]
+    public int TagId { get; set; }
+
+    [JsonPropertyName("creatorid")]
+    public int CreatorId { get; set; }
+
+    [JsonPropertyName("hubcategoryid")]
+    public int HubCategoryId { get; set; }
+    */
+}

--- a/src/Data/Steam/SteamGame.cs
+++ b/src/Data/Steam/SteamGame.cs
@@ -1,6 +1,11 @@
+using System;
 using System.IO;
+using System.Linq;
+using System.Text.Json;
 using System.Threading.Tasks;
+using System.Web;
 using CommunityToolkit.Mvvm.ComponentModel;
+using DLSS_Swapper.Data.Steam.SteamAPI;
 using DLSS_Swapper.Interfaces;
 using SQLite;
 
@@ -49,8 +54,93 @@ namespace DLSS_Swapper.Data.Steam
                 return;
             }
 
+            // Special case for Steamworks redistributable. 
+            if (PlatformId == "228980")
+            {
+                await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/header.jpg").ConfigureAwait(false);
+                return;            
+            }
+
             // If it doesn't exist, load from web.
-            await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/library_600x900_2x.jpg").ConfigureAwait(false);
+            var didDownload = await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/library_600x900_2x.jpg").ConfigureAwait(false);
+
+            // If we couldn't download the cover try getting it from the IStoreBrowseService.
+            if (didDownload == false)
+            {
+                try
+                {
+                    var getItemsInput = new GetItemsInput();
+                    getItemsInput.Ids.Add(new StoreItemId() { AppId = Int32.Parse(PlatformId, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) });
+                    getItemsInput.DataRequest.IncludeAssets = true;
+
+                    var jsonPayload = JsonSerializer.Serialize(getItemsInput);
+                    var payloadUrlEncoded = HttpUtility.UrlEncode(jsonPayload);
+
+                    using (var steamApiResponse = await App.CurrentApp.HttpClient.GetAsync($"https://api.steampowered.com/IStoreBrowseService/GetItems/v1/?input_json={payloadUrlEncoded}", System.Net.Http.HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+                    {
+                        if (steamApiResponse.IsSuccessStatusCode == false)
+                        {
+                            Logger.Error($"Failed to load Steam cover for {PlatformId} from IStoreBrowseService. Status code: {steamApiResponse.StatusCode}");
+                            return;
+                        }
+
+                        using (var responseStream = await steamApiResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                        {
+                            var response = JsonSerializer.Deserialize<SteamAPIResponse<GetItemsResponse>>(responseStream, SourceGenerationContext.Default.SteamAPIResponseGetItemsResponse);
+                            if (response?.Response?.StoreItems.Any() == true)
+                            {
+                                // We are only doing one search, so we likely only care for the first item.
+                                var storeItem = response.Response.StoreItems[0];
+
+                                if (storeItem.Assets is null)
+                                {
+                                    Logger.Error($"No Assets found for {PlatformId} in the response from IStoreBrowseService.");
+                                    return;
+                                }
+
+                                if (string.IsNullOrWhiteSpace(storeItem.Assets.AssetUrlFormat))
+                                {
+                                    Logger.Error($"No AssetUrlFormat found for {PlatformId} in the response from IStoreBrowseService.");
+                                    return;
+                                }
+
+                                // We are only checking LibraryCapsule2x, hopefully it exists for all games
+                                if (string.IsNullOrWhiteSpace(storeItem.Assets.LibraryCapsule2x) == false)
+                                {
+                                    // There are 3 different CDNs, I don't lknow what one they will use, so lets try all of them?
+                                    var cdns = new[]
+                                    {
+                                        "https://shared.fastly.steamstatic.com",
+                                        "https://shared.steamstatic.com",
+                                        "https://shared.akamai.steamstatic.com"
+                                    };
+
+                                    foreach (var cdn in cdns)
+                                    {
+                                        var coverUrl = $"{cdn}/store_item_assets/{storeItem.Assets.AssetUrlFormat.Replace("${FILENAME}", storeItem.Assets.LibraryCapsule2x)}";
+                                        var didDownloadCover = await DownloadCoverAsync(coverUrl).ConfigureAwait(false);
+                                        if (didDownloadCover)
+                                        {
+                                            return;
+                                        }
+                                        Logger.Error($"Could not download cover \"{storeItem.Assets.LibraryCapsule2x}\" with CDN {cdn} so trying next.");
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                Logger.Error($"No store items found for {PlatformId} in the response from IStoreBrowseService.");
+                            }
+                        }
+                    }
+
+                    Logger.Error($"Tried all known methods to get Steam cover for {PlatformId}, but all had failed.");
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex, $"Failed to load Steam cover for {PlatformId} from IStoreBrowseService.");
+                }
+            }
         }
 
         public override bool UpdateFromGame(Game game)

--- a/src/SourceGenerationContext.cs
+++ b/src/SourceGenerationContext.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using DLSS_Swapper.Data.Steam.SteamAPI;
 using Microsoft.UI.Windowing;
 
 namespace DLSS_Swapper;
@@ -19,6 +20,7 @@ namespace DLSS_Swapper;
 [JsonSerializable(typeof(Data.HashedKnownDLL))]
 [JsonSerializable(typeof(Data.GameLibrarySettings))]
 [JsonSerializable(typeof(Dictionary<string, string>))]
+[JsonSerializable(typeof(Data.Steam.SteamAPI.SteamAPIResponse<GetItemsResponse>))]
 internal partial class SourceGenerationContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
## Description of Changes

Some Steam covers do not load. No idea why this is. It seems majority (at least of my installed games) load from the expected area. 

This PR adds fallback to loading from SteamAPI if it couldn't get it previously.

A good test case for this is Battlefield 6 beta.


<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#661

<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
