### PR TITLE
Bugfix/steam loading improvements

### DIFF
--- a/package/NSIS/Installer.nsi
+++ b/package/NSIS/Installer.nsi
@@ -94,13 +94,13 @@ RequestExecutionLevel highest
 ; App version information
 Name "DLSS Swapper"
 !define MUI_ICON "..\..\src\Assets\icon.ico"
-!define MUI_VERSION "1.2.1.0"
+!define MUI_VERSION "1.2.1.1"
 !define MUI_PRODUCT "DLSS Swapper"
-VIProductVersion "1.2.1.0"
+VIProductVersion "1.2.1.1"
 VIAddVersionKey "ProductName" "DLSS Swapper"
-VIAddVersionKey "ProductVersion" "1.2.1.0"
+VIAddVersionKey "ProductVersion" "1.2.1.1"
 VIAddVersionKey "FileDescription" "DLSS Swapper installer"
-VIAddVersionKey "FileVersion" "1.2.1.0"
+VIAddVersionKey "FileVersion" "1.2.1.1"
 
 ; Pages
 !insertmacro MUI_PAGE_WELCOME
@@ -201,7 +201,7 @@ Section
   CreateShortcut "$SMPROGRAMS\DLSS Swapper.lnk" "$INSTDIR\DLSS Swapper.exe"
 
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayName" "DLSS Swapper"
-  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "1.2.1.0"
+  WriteRegStr SHCTX "${UNINST_KEY}" "DisplayVersion" "1.2.1.1"
   WriteRegStr SHCTX "${UNINST_KEY}" "Publisher" "beeradmoore"
   WriteRegStr SHCTX "${UNINST_KEY}" "DisplayIcon" "$\"$INSTDIR\DLSS Swapper.exe$\""
   WriteRegStr SHCTX "${UNINST_KEY}" "UninstallString" "$\"$INSTDIR\uninstall.exe$\""

--- a/package/config.cmd
+++ b/package/config.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-set app_version=1.2.1.0
+set app_version=1.2.1.1
 set initial_directory=%cd%
 
 set csproj_file=..\src\DLSS Swapper.csproj

--- a/src/DLSS Swapper.csproj
+++ b/src/DLSS Swapper.csproj
@@ -16,7 +16,7 @@
     <PackageIcon>Assets\icon_256.png</PackageIcon>
     <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
-    <Version>1.2.1.0</Version>
+    <Version>1.2.1.1</Version>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <PublishSingleFile>false</PublishSingleFile>

--- a/src/DLSS Swapper.csproj
+++ b/src/DLSS Swapper.csproj
@@ -391,6 +391,7 @@
     <PackageReference Include="System.Private.Uri" Version="4.3.2" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+    <PackageReference Include="ValveKeyValue" Version="0.20.0.417" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/Data/Steam/Manifest/AppManifestACF.cs
+++ b/src/Data/Steam/Manifest/AppManifestACF.cs
@@ -1,0 +1,9 @@
+namespace DLSS_Swapper.Data.Steam.Manifest;
+
+internal class AppManifestACF
+{
+    public string AppId { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string StateFlags { get; set; } = string.Empty;
+    public string InstallDir { get; set; } = string.Empty;
+}

--- a/src/Data/Steam/Manifest/LibraryFoldersVDF.cs
+++ b/src/Data/Steam/Manifest/LibraryFoldersVDF.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace DLSS_Swapper.Data.Steam.Manifest;
+
+internal class LibraryFoldersVDF
+{
+    public string Path { get; set; } = string.Empty;
+    public Dictionary<string, string> Apps { get; set; } = new Dictionary<string, string>();
+}

--- a/src/Data/Steam/SteamGame.cs
+++ b/src/Data/Steam/SteamGame.cs
@@ -9,154 +9,153 @@ using DLSS_Swapper.Data.Steam.SteamAPI;
 using DLSS_Swapper.Interfaces;
 using SQLite;
 
-namespace DLSS_Swapper.Data.Steam
+namespace DLSS_Swapper.Data.Steam;
+
+[Table("SteamGame")]
+internal partial class SteamGame : Game
 {
-    [Table("SteamGame")]
-    internal partial class SteamGame : Game
+    public override GameLibrary GameLibrary => GameLibrary.Steam;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsReadyToPlay))]
+    [Column("state_flags")]
+    public partial SteamStateFlag StateFlags { get; set; }
+
+    public override bool IsReadyToPlay
     {
-        public override GameLibrary GameLibrary => GameLibrary.Steam;
-
-        [ObservableProperty]
-        [NotifyPropertyChangedFor(nameof(IsReadyToPlay))]
-        [Column("state_flags")]
-        public partial SteamStateFlag StateFlags { get; set; }
-
-        public override bool IsReadyToPlay
+        get
         {
-            get
+            const SteamStateFlag allowedFlags = SteamStateFlag.StateFullyInstalled | SteamStateFlag.StateAppRunning;
+            return StateFlags != 0 && (StateFlags & ~allowedFlags) == 0;
+        }
+    }
+
+    public SteamGame()
+    {
+
+    }
+
+    public SteamGame(string appId)
+    {
+        PlatformId = appId;
+        SetID();
+    }
+
+    protected override async Task UpdateCacheImageAsync()
+    {
+        // Try get image from the local disk first.
+        var localHeaderImagePath = Path.Combine(SteamLibrary.GetInstallPath(), "appcache", "librarycache", $"{PlatformId}_library_600x900.jpg");
+        if (File.Exists(localHeaderImagePath))
+        {
+            using (var fileStream = File.Open(localHeaderImagePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
-                const SteamStateFlag allowedFlags = SteamStateFlag.StateFullyInstalled | SteamStateFlag.StateAppRunning;
-                return StateFlags != 0 && (StateFlags & ~allowedFlags) == 0;
+                await ResizeCoverAsync(fileStream).ConfigureAwait(false);
             }
+            return;
         }
 
-        public SteamGame()
+        // Special case for Steamworks redistributable. 
+        if (PlatformId == "228980")
         {
-
+            await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/header.jpg").ConfigureAwait(false);
+            return;            
         }
 
-        public SteamGame(string appId)
-        {
-            PlatformId = appId;
-            SetID();
-        }
+        // If it doesn't exist, load from web.
+        var didDownload = await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/library_600x900_2x.jpg").ConfigureAwait(false);
 
-        protected override async Task UpdateCacheImageAsync()
+        // If we couldn't download the cover try getting it from the IStoreBrowseService.
+        if (didDownload == false)
         {
-            // Try get image from the local disk first.
-            var localHeaderImagePath = Path.Combine(SteamLibrary.GetInstallPath(), "appcache", "librarycache", $"{PlatformId}_library_600x900.jpg");
-            if (File.Exists(localHeaderImagePath))
+            try
             {
-                using (var fileStream = File.Open(localHeaderImagePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                var getItemsInput = new GetItemsInput();
+                getItemsInput.Ids.Add(new StoreItemId() { AppId = Int32.Parse(PlatformId, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) });
+                getItemsInput.DataRequest.IncludeAssets = true;
+
+                var jsonPayload = JsonSerializer.Serialize(getItemsInput);
+                var payloadUrlEncoded = HttpUtility.UrlEncode(jsonPayload);
+
+                using (var steamApiResponse = await App.CurrentApp.HttpClient.GetAsync($"https://api.steampowered.com/IStoreBrowseService/GetItems/v1/?input_json={payloadUrlEncoded}", System.Net.Http.HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
                 {
-                    await ResizeCoverAsync(fileStream).ConfigureAwait(false);
-                }
-                return;
-            }
-
-            // Special case for Steamworks redistributable. 
-            if (PlatformId == "228980")
-            {
-                await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/header.jpg").ConfigureAwait(false);
-                return;            
-            }
-
-            // If it doesn't exist, load from web.
-            var didDownload = await DownloadCoverAsync($"https://steamcdn-a.akamaihd.net/steam/apps/{PlatformId}/library_600x900_2x.jpg").ConfigureAwait(false);
-
-            // If we couldn't download the cover try getting it from the IStoreBrowseService.
-            if (didDownload == false)
-            {
-                try
-                {
-                    var getItemsInput = new GetItemsInput();
-                    getItemsInput.Ids.Add(new StoreItemId() { AppId = Int32.Parse(PlatformId, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture) });
-                    getItemsInput.DataRequest.IncludeAssets = true;
-
-                    var jsonPayload = JsonSerializer.Serialize(getItemsInput);
-                    var payloadUrlEncoded = HttpUtility.UrlEncode(jsonPayload);
-
-                    using (var steamApiResponse = await App.CurrentApp.HttpClient.GetAsync($"https://api.steampowered.com/IStoreBrowseService/GetItems/v1/?input_json={payloadUrlEncoded}", System.Net.Http.HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false))
+                    if (steamApiResponse.IsSuccessStatusCode == false)
                     {
-                        if (steamApiResponse.IsSuccessStatusCode == false)
-                        {
-                            Logger.Error($"Failed to load Steam cover for {PlatformId} from IStoreBrowseService. Status code: {steamApiResponse.StatusCode}");
-                            return;
-                        }
-
-                        using (var responseStream = await steamApiResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))
-                        {
-                            var response = JsonSerializer.Deserialize<SteamAPIResponse<GetItemsResponse>>(responseStream, SourceGenerationContext.Default.SteamAPIResponseGetItemsResponse);
-                            if (response?.Response?.StoreItems.Any() == true)
-                            {
-                                // We are only doing one search, so we likely only care for the first item.
-                                var storeItem = response.Response.StoreItems[0];
-
-                                if (storeItem.Assets is null)
-                                {
-                                    Logger.Error($"No Assets found for {PlatformId} in the response from IStoreBrowseService.");
-                                    return;
-                                }
-
-                                if (string.IsNullOrWhiteSpace(storeItem.Assets.AssetUrlFormat))
-                                {
-                                    Logger.Error($"No AssetUrlFormat found for {PlatformId} in the response from IStoreBrowseService.");
-                                    return;
-                                }
-
-                                // We are only checking LibraryCapsule2x, hopefully it exists for all games
-                                if (string.IsNullOrWhiteSpace(storeItem.Assets.LibraryCapsule2x) == false)
-                                {
-                                    // There are 3 different CDNs, I don't lknow what one they will use, so lets try all of them?
-                                    var cdns = new[]
-                                    {
-                                        "https://shared.fastly.steamstatic.com",
-                                        "https://shared.steamstatic.com",
-                                        "https://shared.akamai.steamstatic.com"
-                                    };
-
-                                    foreach (var cdn in cdns)
-                                    {
-                                        var coverUrl = $"{cdn}/store_item_assets/{storeItem.Assets.AssetUrlFormat.Replace("${FILENAME}", storeItem.Assets.LibraryCapsule2x)}";
-                                        var didDownloadCover = await DownloadCoverAsync(coverUrl).ConfigureAwait(false);
-                                        if (didDownloadCover)
-                                        {
-                                            return;
-                                        }
-                                        Logger.Error($"Could not download cover \"{storeItem.Assets.LibraryCapsule2x}\" with CDN {cdn} so trying next.");
-                                    }
-                                }
-                            }
-                            else
-                            {
-                                Logger.Error($"No store items found for {PlatformId} in the response from IStoreBrowseService.");
-                            }
-                        }
+                        Logger.Error($"Failed to load Steam cover for {PlatformId} from IStoreBrowseService. Status code: {steamApiResponse.StatusCode}");
+                        return;
                     }
 
-                    Logger.Error($"Tried all known methods to get Steam cover for {PlatformId}, but all had failed.");
+                    using (var responseStream = await steamApiResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))
+                    {
+                        var response = JsonSerializer.Deserialize<SteamAPIResponse<GetItemsResponse>>(responseStream, SourceGenerationContext.Default.SteamAPIResponseGetItemsResponse);
+                        if (response?.Response?.StoreItems.Any() == true)
+                        {
+                            // We are only doing one search, so we likely only care for the first item.
+                            var storeItem = response.Response.StoreItems[0];
+
+                            if (storeItem.Assets is null)
+                            {
+                                Logger.Error($"No Assets found for {PlatformId} in the response from IStoreBrowseService.");
+                                return;
+                            }
+
+                            if (string.IsNullOrWhiteSpace(storeItem.Assets.AssetUrlFormat))
+                            {
+                                Logger.Error($"No AssetUrlFormat found for {PlatformId} in the response from IStoreBrowseService.");
+                                return;
+                            }
+
+                            // We are only checking LibraryCapsule2x, hopefully it exists for all games
+                            if (string.IsNullOrWhiteSpace(storeItem.Assets.LibraryCapsule2x) == false)
+                            {
+                                // There are 3 different CDNs, I don't lknow what one they will use, so lets try all of them?
+                                var cdns = new[]
+                                {
+                                    "https://shared.fastly.steamstatic.com",
+                                    "https://shared.steamstatic.com",
+                                    "https://shared.akamai.steamstatic.com"
+                                };
+
+                                foreach (var cdn in cdns)
+                                {
+                                    var coverUrl = $"{cdn}/store_item_assets/{storeItem.Assets.AssetUrlFormat.Replace("${FILENAME}", storeItem.Assets.LibraryCapsule2x)}";
+                                    var didDownloadCover = await DownloadCoverAsync(coverUrl).ConfigureAwait(false);
+                                    if (didDownloadCover)
+                                    {
+                                        return;
+                                    }
+                                    Logger.Error($"Could not download cover \"{storeItem.Assets.LibraryCapsule2x}\" with CDN {cdn} so trying next.");
+                                }
+                            }
+                        }
+                        else
+                        {
+                            Logger.Error($"No store items found for {PlatformId} in the response from IStoreBrowseService.");
+                        }
+                    }
                 }
-                catch (Exception ex)
-                {
-                    Logger.Error(ex, $"Failed to load Steam cover for {PlatformId} from IStoreBrowseService.");
-                }
+
+                Logger.Error($"Tried all known methods to get Steam cover for {PlatformId}, but all had failed.");
             }
-        }
-
-        public override bool UpdateFromGame(Game game)
-        {
-            var didChange = ParentUpdateFromGame(game);
-
-            if (game is SteamGame steamGame)
+            catch (Exception ex)
             {
-                if (StateFlags != steamGame.StateFlags)
-                {
-                    StateFlags = steamGame.StateFlags;
-                    didChange = true;
-                }
+                Logger.Error(ex, $"Failed to load Steam cover for {PlatformId} from IStoreBrowseService.");
             }
-
-            return didChange;
         }
+    }
+
+    public override bool UpdateFromGame(Game game)
+    {
+        var didChange = ParentUpdateFromGame(game);
+
+        if (game is SteamGame steamGame)
+        {
+            if (StateFlags != steamGame.StateFlags)
+            {
+                StateFlags = steamGame.StateFlags;
+                didChange = true;
+            }
+        }
+
+        return didChange;
     }
 }

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -10,271 +10,270 @@ using System.Linq;
 using System.Threading.Tasks;
 using ValveKeyValue;
 
-namespace DLSS_Swapper.Data.Steam
+namespace DLSS_Swapper.Data.Steam;
+
+internal partial class SteamLibrary : IGameLibrary
 {
-    internal partial class SteamLibrary : IGameLibrary
+    public GameLibrary GameLibrary => GameLibrary.Steam;
+    public string Name => "Steam";
+
+    public Type GameType => typeof(SteamGame);
+
+    static SteamLibrary? instance;
+    public static SteamLibrary Instance => instance ??= new SteamLibrary();
+
+    GameLibrarySettings? _gameLibrarySettings;
+    public GameLibrarySettings? GameLibrarySettings => _gameLibrarySettings ??= GameManager.Instance.GetGameLibrarySettings(GameLibrary);
+
+    static string _installPath = string.Empty;
+
+    private SteamLibrary()
     {
-        public GameLibrary GameLibrary => GameLibrary.Steam;
-        public string Name => "Steam";
 
-        public Type GameType => typeof(SteamGame);
+    }
 
-        static SteamLibrary? instance;
-        public static SteamLibrary Instance => instance ??= new SteamLibrary();
+    public bool IsInstalled()
+    {
+        return string.IsNullOrEmpty(GetInstallPath()) == false;
+    }
 
-        GameLibrarySettings? _gameLibrarySettings;
-        public GameLibrarySettings? GameLibrarySettings => _gameLibrarySettings ??= GameManager.Instance.GetGameLibrarySettings(GameLibrary);
+    readonly string[] _defaultHiddenGames = [
+        "228980", // Steamworks Common Redistributables
+];
 
-        static string _installPath = string.Empty;
-
-        private SteamLibrary()
+    public async Task<List<Game>> ListGamesAsync(bool forceNeedsProcessing = false)
+    {
+        // If we don't detect a steam install patg return an empty list.
+        if (IsInstalled() == false)
         {
-
+            return new List<Game>();
         }
 
-        public bool IsInstalled()
+        var cachedGames = GameManager.Instance.GetGames<SteamGame>();
+
+        var installPath = GetInstallPath();
+
+
+        // I hope this runs on a background thread. 
+        // Tasks are whack.
+
+        // Base steamapps folder contains libraryfolders.vdf which has references to other steamapps folders and individual installed Steam games.
+        // All of these folders contain appmanifest_[some_id].acf which contains information about the game.
+
+        var baseSteamAppsFolder = Path.Combine(installPath, "steamapps");
+        var libraryFoldersFile = Path.Combine(baseSteamAppsFolder, "libraryfolders.vdf");
+        if (File.Exists(libraryFoldersFile) == false)
         {
-            return string.IsNullOrEmpty(GetInstallPath()) == false;
+            return new List<Game>();
         }
 
-        readonly string[] _defaultHiddenGames = [
-            "228980", // Steamworks Common Redistributables
-    ];
+        var allAppManifestPaths = new List<string>();
+        var kvSerializer = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
 
-        public async Task<List<Game>> ListGamesAsync(bool forceNeedsProcessing = false)
+        try
         {
-            // If we don't detect a steam install patg return an empty list.
-            if (IsInstalled() == false)
+            using (var fileStream = File.OpenRead(libraryFoldersFile))
             {
-                return new List<Game>();
-            }
-
-            var cachedGames = GameManager.Instance.GetGames<SteamGame>();
-
-            var installPath = GetInstallPath();
-
-
-            // I hope this runs on a background thread. 
-            // Tasks are whack.
-
-            // Base steamapps folder contains libraryfolders.vdf which has references to other steamapps folders and individual installed Steam games.
-            // All of these folders contain appmanifest_[some_id].acf which contains information about the game.
-
-            var baseSteamAppsFolder = Path.Combine(installPath, "steamapps");
-            var libraryFoldersFile = Path.Combine(baseSteamAppsFolder, "libraryfolders.vdf");
-            if (File.Exists(libraryFoldersFile) == false)
-            {
-                return new List<Game>();
-            }
-
-            var allAppManifestPaths = new List<string>();
-            var kvSerializer = KVSerializer.Create(KVSerializationFormat.KeyValues1Text);
-
-            try
-            {
-                using (var fileStream = File.OpenRead(libraryFoldersFile))
+                var libraryFoldersVDF = kvSerializer.Deserialize<Dictionary<string, LibraryFoldersVDF>>(fileStream);
+                foreach (var libraryFolderVDF in libraryFoldersVDF)
                 {
-                    var libraryFoldersVDF = kvSerializer.Deserialize<Dictionary<string, LibraryFoldersVDF>>(fileStream);
-                    foreach (var libraryFolderVDF in libraryFoldersVDF)
-                    {
-                        var path = PathHelpers.NormalizePath(libraryFolderVDF.Value.Path);
-                        path = Path.Combine(path, "steamapps");
+                    var path = PathHelpers.NormalizePath(libraryFolderVDF.Value.Path);
+                    path = Path.Combine(path, "steamapps");
 
-                        foreach (var steamApp in libraryFolderVDF.Value.Apps)
+                    foreach (var steamApp in libraryFolderVDF.Value.Apps)
+                    {
+                        // Here steamApp.Value would be size on disk.
+                        var appManifestPath = Path.Combine(path, $"appmanifest_{steamApp.Key}.acf");
+                        if (File.Exists(appManifestPath))
                         {
-                            // Here steamApp.Value would be size on disk.
-                            var appManifestPath = Path.Combine(path, $"appmanifest_{steamApp.Key}.acf");
-                            if (File.Exists(appManifestPath))
-                            {
-                                allAppManifestPaths.Add(appManifestPath);
-                            }
-                            else
-                            {
-                                Logger.Error($"Expected manifest path was not found - {appManifestPath}");
-                            }
+                            allAppManifestPaths.Add(appManifestPath);
+                        }
+                        else
+                        {
+                            Logger.Error($"Expected manifest path was not found - {appManifestPath}");
                         }
                     }
                 }
             }
-            catch (Exception err)
-            {
-                Logger.Error(err, $"Unable to process {libraryFoldersFile}");
-                Debugger.Break();
-            }
-
-            var games = new List<Game>();
-
-            foreach (var appManifestPath in allAppManifestPaths)
-            {
-                SteamGame? game;
-
-                try
-                {
-                    using (var fileStream = File.OpenRead(appManifestPath))
-                    {
-                        var appManifestACF = kvSerializer.Deserialize<AppManifestACF>(fileStream);
-
-                        if (appManifestACF is null || string.IsNullOrEmpty(appManifestACF.AppId))
-                        {
-                            Logger.Error($"Unable to parse app manifest - {appManifestPath}");
-                            continue;
-                        }
-
-                        game = new SteamGame(appManifestACF.AppId);
-
-                        if (Enum.TryParse(appManifestACF.StateFlags, out SteamStateFlag stateFlags) == false)
-                        {
-                            // The AppState couldn't be parsed from the appmanifest_*.acf
-                            Logger.Error($"Unable to parse StateFlags {appManifestACF.StateFlags} for app {appManifestACF.AppId} in {appManifestPath}");
-                            continue;
-                        }
-                        game.StateFlags = stateFlags;
-                        game.Title = appManifestACF.Name;
-
-                        var baseDir = Path.GetDirectoryName(appManifestPath);
-                        if (string.IsNullOrEmpty(baseDir))
-                        {
-                            continue;
-                        }
-
-                        var installDir = PathHelpers.NormalizePath(Path.Combine(baseDir, "common", appManifestACF.InstallDir));
-                        if (Directory.Exists(installDir) == false)
-                        {
-                            // If the install directory does not exist, skip this game.
-                            Logger.Error($"SteamLibary could not load game {game.Title} ({game.PlatformId}) because install path does not exist: {installDir}");
-                            continue;
-                        }
-                        game.InstallPath = installDir;
-                    }
-                }
-                catch (Exception err)
-                {
-                    Logger.Error(err);
-                    continue;
-                }
-
-                var cachedGame = GameManager.Instance.GetGame<SteamGame>(game.PlatformId);
-                var activeGame = cachedGame ?? game;
-
-                if (activeGame.IsHidden is null && _defaultHiddenGames.Contains(activeGame.PlatformId))
-                {
-                    activeGame.IsHidden = true;
-                }
-
-
-                activeGame.Title = game.Title;  // TODO: Will this be a problem if the game is already loaded
-                activeGame.InstallPath = game.InstallPath;
-                activeGame.StateFlags = game.StateFlags;
-
-                if (activeGame.IsInIgnoredPath())
-                {
-                    continue;
-                }
-
-                await activeGame.SaveToDatabaseAsync().ConfigureAwait(false);
-
-                // If the game is not from cache, force processing
-                if (cachedGame is null)
-                {
-                    activeGame.NeedsProcessing = true;
-                }
-
-                if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
-                {
-                    activeGame.ProcessGame();
-                }
-
-                games.Add(activeGame);
-            }
-
-
-            games.Sort();
-
-            // Delete games that are no longer loaded, they are likely uninstalled
-            foreach (var cachedGame in cachedGames)
-            {
-                // Game is to be deleted.
-                if (games.Contains(cachedGame) == false)
-                {
-                    await cachedGame.DeleteAsync().ConfigureAwait(false);
-                }
-            }
-
-            return games;
+        }
+        catch (Exception err)
+        {
+            Logger.Error(err, $"Unable to process {libraryFoldersFile}");
+            Debugger.Break();
         }
 
-        public static string GetInstallPath()
+        var games = new List<Game>();
+
+        foreach (var appManifestPath in allAppManifestPaths)
         {
-            if (string.IsNullOrEmpty(_installPath) == false)
-            {
-                return _installPath;
-            }
+            SteamGame? game;
 
             try
             {
-                using (var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+                using (var fileStream = File.OpenRead(appManifestPath))
                 {
-                    using (var steamRegistryKey = hklm.OpenSubKey(@"SOFTWARE\Valve\Steam"))
+                    var appManifestACF = kvSerializer.Deserialize<AppManifestACF>(fileStream);
+
+                    if (appManifestACF is null || string.IsNullOrEmpty(appManifestACF.AppId))
                     {
-                        // if steamRegistryKey is null then Steam is not installed.
-                        if (steamRegistryKey is null)
-                        {
-                            return string.Empty;
-                        }
-
-                        var installPath = steamRegistryKey.GetValue("InstallPath") as string ?? string.Empty;
-                        if (string.IsNullOrEmpty(installPath) == false && Directory.Exists(installPath))
-                        {
-                            _installPath = installPath;
-                        }
-
-                        return _installPath;
+                        Logger.Error($"Unable to parse app manifest - {appManifestPath}");
+                        continue;
                     }
-                }
-            }
-            catch (Exception err)
-            {
-                _installPath = string.Empty;
-                Logger.Error(err);
-                return string.Empty;
-            }
-        }
 
-        public async Task LoadGamesFromCacheAsync()
-        {
-            try
-            {
-                SteamGame[] games;
-                using (await Database.Instance.Mutex.LockAsync())
-                {
-                    games = await Database.Instance.Connection.Table<SteamGame>().ToArrayAsync().ConfigureAwait(false);
-                }
-                foreach (var game in games)
-                {
-                    if (game.IsInIgnoredPath())
+                    game = new SteamGame(appManifestACF.AppId);
+
+                    if (Enum.TryParse(appManifestACF.StateFlags, out SteamStateFlag stateFlags) == false)
+                    {
+                        // The AppState couldn't be parsed from the appmanifest_*.acf
+                        Logger.Error($"Unable to parse StateFlags {appManifestACF.StateFlags} for app {appManifestACF.AppId} in {appManifestPath}");
+                        continue;
+                    }
+                    game.StateFlags = stateFlags;
+                    game.Title = appManifestACF.Name;
+
+                    var baseDir = Path.GetDirectoryName(appManifestPath);
+                    if (string.IsNullOrEmpty(baseDir))
                     {
                         continue;
                     }
 
-                    if (Directory.Exists(game.InstallPath) == false)
+                    var installDir = PathHelpers.NormalizePath(Path.Combine(baseDir, "common", appManifestACF.InstallDir));
+                    if (Directory.Exists(installDir) == false)
                     {
-                        Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
-                        // We remove the list of known game assets, but not the game itself.
-                        // Removing the game will remove its history, notes, and other data.
-                        // We don't want to do this in case it is just a temporary issue.
-                        await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
+                        // If the install directory does not exist, skip this game.
+                        Logger.Error($"SteamLibary could not load game {game.Title} ({game.PlatformId}) because install path does not exist: {installDir}");
                         continue;
                     }
-
-                    await game.LoadGameAssetsFromCacheAsync().ConfigureAwait(false);
-                    GameManager.Instance.AddGame(game);
+                    game.InstallPath = installDir;
                 }
             }
             catch (Exception err)
             {
                 Logger.Error(err);
-                Debugger.Break();
+                continue;
             }
+
+            var cachedGame = GameManager.Instance.GetGame<SteamGame>(game.PlatformId);
+            var activeGame = cachedGame ?? game;
+
+            if (activeGame.IsHidden is null && _defaultHiddenGames.Contains(activeGame.PlatformId))
+            {
+                activeGame.IsHidden = true;
+            }
+
+
+            activeGame.Title = game.Title;  // TODO: Will this be a problem if the game is already loaded
+            activeGame.InstallPath = game.InstallPath;
+            activeGame.StateFlags = game.StateFlags;
+
+            if (activeGame.IsInIgnoredPath())
+            {
+                continue;
+            }
+
+            await activeGame.SaveToDatabaseAsync().ConfigureAwait(false);
+
+            // If the game is not from cache, force processing
+            if (cachedGame is null)
+            {
+                activeGame.NeedsProcessing = true;
+            }
+
+            if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
+            {
+                activeGame.ProcessGame();
+            }
+
+            games.Add(activeGame);
+        }
+
+
+        games.Sort();
+
+        // Delete games that are no longer loaded, they are likely uninstalled
+        foreach (var cachedGame in cachedGames)
+        {
+            // Game is to be deleted.
+            if (games.Contains(cachedGame) == false)
+            {
+                await cachedGame.DeleteAsync().ConfigureAwait(false);
+            }
+        }
+
+        return games;
+    }
+
+    public static string GetInstallPath()
+    {
+        if (string.IsNullOrEmpty(_installPath) == false)
+        {
+            return _installPath;
+        }
+
+        try
+        {
+            using (var hklm = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32))
+            {
+                using (var steamRegistryKey = hklm.OpenSubKey(@"SOFTWARE\Valve\Steam"))
+                {
+                    // if steamRegistryKey is null then Steam is not installed.
+                    if (steamRegistryKey is null)
+                    {
+                        return string.Empty;
+                    }
+
+                    var installPath = steamRegistryKey.GetValue("InstallPath") as string ?? string.Empty;
+                    if (string.IsNullOrEmpty(installPath) == false && Directory.Exists(installPath))
+                    {
+                        _installPath = installPath;
+                    }
+
+                    return _installPath;
+                }
+            }
+        }
+        catch (Exception err)
+        {
+            _installPath = string.Empty;
+            Logger.Error(err);
+            return string.Empty;
+        }
+    }
+
+    public async Task LoadGamesFromCacheAsync()
+    {
+        try
+        {
+            SteamGame[] games;
+            using (await Database.Instance.Mutex.LockAsync())
+            {
+                games = await Database.Instance.Connection.Table<SteamGame>().ToArrayAsync().ConfigureAwait(false);
+            }
+            foreach (var game in games)
+            {
+                if (game.IsInIgnoredPath())
+                {
+                    continue;
+                }
+
+                if (Directory.Exists(game.InstallPath) == false)
+                {
+                    Logger.Warning($"{Name} library could not load game {game.Title} ({game.PlatformId}) from cache because install path does not exist: {game.InstallPath}");
+                    // We remove the list of known game assets, but not the game itself.
+                    // Removing the game will remove its history, notes, and other data.
+                    // We don't want to do this in case it is just a temporary issue.
+                    await game.RemoveGameAssetsFromCacheAsync().ConfigureAwait(false);
+                    continue;
+                }
+
+                await game.LoadGameAssetsFromCacheAsync().ConfigureAwait(false);
+                GameManager.Instance.AddGame(game);
+            }
+        }
+        catch (Exception err)
+        {
+            Logger.Error(err);
+            Debugger.Break();
         }
     }
 }

--- a/src/app.manifest
+++ b/src/app.manifest
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
-  <assemblyIdentity version="1.2.1.0" name="DLSS Swapper.app"/>
+  <assemblyIdentity version="1.2.1.1" name="DLSS Swapper.app"/>
 
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>


### PR DESCRIPTION
## Description of Changes

This does a few things.
1. Swaps loading from our jank regex to using [ValveKeyValue](https://github.com/ValveResourceFormat/ValveKeyValue)
2. Only loads games that are found in `libraryfolders.acf`. This prevents issues with rogue `appmaniest_XYZ.acf` files causing incorrect game locations.
3. Removed some warnings around Steam when building




<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

This fixes the underlying problem that casued #683.
Same issue that is likley causing #361
There was another issue but I can't find it currently.


<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
