### PR TITLE
Fix Spanish and Catalan translations for DLSS and XeSS

### DIFF
--- a/src/Translations/ca-ES/Resources.resw
+++ b/src/Translations/ca-ES/Resources.resw
@@ -508,10 +508,10 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>DLSS</value>
   </data>
   <data name="General_Name_DLSS_D" xml:space="preserve">
-    <value>Reconstrucció de Raigs de DLSS</value>
+    <value>Reconstrucció de Raigs DLSS</value>
   </data>
   <data name="General_Name_DLSS_G" xml:space="preserve">
-    <value>Generació de Fotogrames de DLSS</value>
+    <value>Generació de Fotogrames DLSS</value>
   </data>
   <data name="General_Name_DLSS_Preset" xml:space="preserve">
     <value>Perfil de DLSS</value>
@@ -529,7 +529,7 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
     <value>XeSS</value>
   </data>
   <data name="General_Name_XeSS_FG" xml:space="preserve">
-    <value>Generació de Fotogrames de XeSS</value>
+    <value>Generació de Fotogrames XeSS</value>
   </data>
   <data name="General_No" xml:space="preserve">
     <value>No</value>

--- a/src/Translations/es-ES/Resources.resw
+++ b/src/Translations/es-ES/Resources.resw
@@ -508,10 +508,10 @@ Si has comprobado esto y tu juego sigue sin aparecer, puede que haya un error. A
     <value>DLSS</value>
   </data>
   <data name="General_Name_DLSS_D" xml:space="preserve">
-    <value>Reconstrucción de Rayos de DLSS</value>
+    <value>Reconstrucción de Rayos DLSS</value>
   </data>
   <data name="General_Name_DLSS_G" xml:space="preserve">
-    <value>Generación de Fotogramas de DLSS</value>
+    <value>Generación de Fotogramas DLSS</value>
   </data>
   <data name="General_Name_DLSS_Preset" xml:space="preserve">
     <value>Perfil de DLSS</value>
@@ -529,7 +529,7 @@ Si has comprobado esto y tu juego sigue sin aparecer, puede que haya un error. A
     <value>XeSS</value>
   </data>
   <data name="General_Name_XeSS_FG" xml:space="preserve">
-    <value>Generación de Fotogramas de XeSS</value>
+    <value>Generación de Fotogramas XeSS</value>
   </data>
   <data name="General_No" xml:space="preserve">
     <value>No</value>


### PR DESCRIPTION
## Description of Changes

Fixed Catalan and Spanish translations for DLSS and XeSS related terms by removing unnecessary prepositions for making space to the text.

<img width="762" height="676" alt="image" src="https://github.com/user-attachments/assets/f7e71254-8a11-49cf-b87e-b2feb6d71323" />
<br/>
In Spanish, for exemple, the text doesn't display correctly due to the length of the sentence (the same goes for Catalan).
<br/>
<br/>
<br/>


<img width="760" height="676" alt="image" src="https://github.com/user-attachments/assets/337c6935-4d47-4e07-9c6c-99c24bc65598" />
<br/>
In Catalan it's fixed... 
<br/>
<br/>
<br/>
<img width="768" height="661" alt="image" src="https://github.com/user-attachments/assets/d63be989-ae90-49b1-835b-a988a39f2eba" />
<br/>
...but not at all in Spanish.

<br/>
<br/>

I'll open an issue for this.


## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Translation update