### PR TITLE
Add force reloading of game covers

### DIFF
--- a/src/Data/BattleNet/BattleNetLibrary.cs
+++ b/src/Data/BattleNet/BattleNetLibrary.cs
@@ -204,7 +204,7 @@ internal partial class BattleNetLibrary : IGameLibrary
 
                 if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
                 {
-                    activeGame.ProcessGame();
+                    activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                 }
 
                 games.Add(activeGame);

--- a/src/Data/EAApp/EAAppLibrary.cs
+++ b/src/Data/EAApp/EAAppLibrary.cs
@@ -195,7 +195,7 @@ internal class EAAppLibrary : IGameLibrary
 
                                     if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
                                     {
-                                        activeGame.ProcessGame();
+                                        activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                                     }
 
                                     lock (gameListLock)

--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -174,7 +174,7 @@ namespace DLSS_Swapper.Data.EpicGamesStore
 
                     if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
                     {
-                        activeGame.ProcessGame();
+                        activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                     }
 
                     games.Add(activeGame);

--- a/src/Data/GOG/GOGLibrary.cs
+++ b/src/Data/GOG/GOGLibrary.cs
@@ -298,7 +298,7 @@ namespace DLSS_Swapper.Data.GOG
 
                 if (gogGame.NeedsProcessing == true || forceNeedsProcessing == true)
                 {
-                    gogGame.ProcessGame();
+                    gogGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                 }
             }
 

--- a/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
+++ b/src/Data/ManuallyAdded/ManuallyAddedLibrary.cs
@@ -53,7 +53,7 @@ public class ManuallyAddedLibrary : IGameLibrary
 
             if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
             {
-                activeGame.ProcessGame();
+                activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
             }
 
             games.Add(activeGame);

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -245,7 +245,7 @@ internal partial class SteamLibrary : IGameLibrary
 
             if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
             {
-                activeGame.ProcessGame();
+                activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
             }
 
             games.Add(activeGame);

--- a/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
+++ b/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
@@ -246,7 +246,7 @@ namespace DLSS_Swapper.Data.UbisoftConnect
 
                                 if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
                                 {
-                                    activeGame.ProcessGame();
+                                    activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                                 }
 
                                 games.Add(activeGame);

--- a/src/Data/Xbox/XboxLibrary.cs
+++ b/src/Data/Xbox/XboxLibrary.cs
@@ -258,7 +258,7 @@ namespace DLSS_Swapper.Data.Xbox
 
                         if (activeGame.NeedsProcessing == true || forceNeedsProcessing == true)
                         {
-                            activeGame.ProcessGame();
+                            activeGame.ProcessGame(forceNeedsProcessing: forceNeedsProcessing);
                         }
                         games.Add(activeGame);
                     }

--- a/src/UserControls/GameControlModel.cs
+++ b/src/UserControls/GameControlModel.cs
@@ -450,7 +450,7 @@ public partial class GameControlModel : ObservableObject
 
             Game.PropertyChanged += Game_PropertyChanged;
             Game.NeedsProcessing = true;
-            Game.ProcessGame();
+            Game.ProcessGame(forceNeedsProcessing: true);
 
             var dialogStart = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
 


### PR DESCRIPTION
## Description of Changes

Passes through the force reload property to processgame method allowing us to know if we should also force reload the cover.

<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

None reported yet, would have impacted users using BF6 and still had a grey image.

<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
