### PR TITLE
Fixes an issue where closing a window while minimized won't yeet it to -32000 x/y pos

### DIFF
--- a/src/Data/WindowPositionRect.cs
+++ b/src/Data/WindowPositionRect.cs
@@ -35,10 +35,34 @@ public class WindowPositionRect
         Width = other.Width;
         Height = other.Height;
         State = other.State;
+
+        // -32000 is some magic number were windows go to die.
+        if (X == -32000)
+        {
+            X = 0;
+        }
+
+        if (Y == -32000)
+        {
+            Y = 0;
+        }
+
     }
 
     public WindowPositionRect(int x, int y, int width, int height)
     {
+        // -32000 is some magic number were windows go to die.
+        // This is to help apps that are already broken to show the main window again.
+        if (x == -32000)
+        {
+            x = 0;
+        }
+
+        if (y == -32000)
+        {
+            y = 0;
+        }
+
         X = x;
         Y = y;
         Width = width;
@@ -47,17 +71,41 @@ public class WindowPositionRect
 
     public RectInt32 GetRectInt32()
     {
+        // -32000 is some magic number were windows go to die.
+        // This is to help apps that are already broken to show the main window again.
+        if (X == -32000)
+        {
+            X = 0;
+        }
+
+        if (Y == -32000)
+        {
+            Y = 0;
+        }
+
         return new RectInt32(X, Y, Width, Height);
     }
 
     public void UpdatePosition(PointInt32 position)
     {
+        // -32000 is some magic number were windows go to die.
+        if (position.X == -32000 || position.Y == -32000)
+        {
+            return;
+        }
+
         X = position.X;
         Y = position.Y;
     }
 
     public void UpdateFromAppWindow(AppWindow appWindow)
     {
+        // -32000 is some magic number were windows go to die.
+        if (appWindow.Position.X == -32000 || appWindow.Position.Y == -32000)
+        {
+            return;
+        }
+
         Width = appWindow.Size.Width;
         Height = appWindow.Size.Height;
         X = appWindow.Position.X;


### PR DESCRIPTION
## Description of Changes

If you minmise a window Windows sets the X/Y position to -32000, If you then close the window and re-open DLSS Swapper we will try put it at that position for it to never be seen again.

<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#829


<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
