### PR TITLE
Fix typo in German translation

### DIFF
--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -172,7 +172,7 @@
     <value>Standard</value>
   </data>
   <data name="DLSS_Preset_Letter" xml:space="preserve">
-    <value>Voreinstelung {0}</value>
+    <value>Voreinstellung {0}</value>
   </data>
   <data name="DLSS_Preset_Letter_Deprecated" xml:space="preserve">
     <value>Voreinstellung {0} (veraltet)</value>


### PR DESCRIPTION
## Description of Changes

I fixed a typo in the German translation

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Translation update
