### PR TITLE
feature/auto-import-ngx

### DIFF
--- a/.github/workflows/build-for-distribute.yml
+++ b/.github/workflows/build-for-distribute.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Setup .NET 10.0
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '10.0.100'
+        dotnet-version: '10.0.201'
 
     - name: Display .NET Info
       run: dotnet --info

--- a/extras/InNeedOfTranslationDetector/InNeedOfTranslationDetector/Program.cs
+++ b/extras/InNeedOfTranslationDetector/InNeedOfTranslationDetector/Program.cs
@@ -60,6 +60,9 @@ var ignoredXamlMatches = new List<string>()
     "Text=\"&#xE8C8;\"",
     "Text=\"DLSS Preset\"",
 	"FallbackValue='N/A'",
+	"Text=\"NVIDIA\"",
+	"Text=\"AMD\"",
+	"Text=\"Intel\"",
 };
 
 foreach (var xamlFile in allXamlFiles)
@@ -241,7 +244,13 @@ var ignoredCSharpMatches = new List<string>()
 	"= \"228980\"",
 	" = \"US\"",
 	" = $\"shell:appsFolder\\\\{xboxGame.PlatformId}!{xboxGame.ApplicationId}\"",
-
+	"=\"filePath\"",
+	"=\"zippedDllFullName\"",
+	"=\"overrideFileName\"",
+	"= \"libxess_dx11.dll\"",
+	"=\"%1\"",
+	"=\"launch {LauncherId}\"",
+	" = \"http://s3.amazonaws.com/doc/2006-03-01/\"",
 };
 
 

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -21,8 +21,8 @@ public sealed partial class App : Application
 {
     public ElementTheme GlobalElementTheme { get; set; }
 
-    MainWindow? _window;
-    public MainWindow MainWindow => _window ??= new MainWindow();
+    MainWindow? _mainWindow;
+    public MainWindow MainWindow => _mainWindow;
     public WindowManager WindowManager { get; } = new WindowManager();
 
     public static App CurrentApp => (App)Application.Current;
@@ -170,7 +170,11 @@ public sealed partial class App : Application
 
         Database.Instance.Init();
 
-        WindowManager.ShowWindow(MainWindow);
+        if (_mainWindow is null)
+        {
+            _mainWindow = new MainWindow();
+        }
+        WindowManager.ShowWindow(_mainWindow);
 
 #if !PORTABLE
         // No need to calculate this for portable app.
@@ -310,9 +314,9 @@ public sealed partial class App : Application
             return true;
         }
 
-        if (MainWindow?.DispatcherQueue is not null)
+        if (_mainWindow?.DispatcherQueue is not null)
         {
-            var didEnqueue = MainWindow.DispatcherQueue.TryEnqueue(new DispatcherQueueHandler(action));
+            var didEnqueue = _mainWindow.DispatcherQueue.TryEnqueue(new DispatcherQueueHandler(action));
 
             if (didEnqueue == false)
             {
@@ -341,9 +345,9 @@ public sealed partial class App : Application
             return function();
         }
 
-        if (MainWindow?.DispatcherQueue is not null)
+        if (_mainWindow?.DispatcherQueue is not null)
         {
-            return MainWindow.DispatcherQueue.EnqueueAsync(function);
+            return _mainWindow.DispatcherQueue.EnqueueAsync(function);
         }
 
         return Task.CompletedTask;

--- a/src/App.xaml.cs
+++ b/src/App.xaml.cs
@@ -22,7 +22,9 @@ public sealed partial class App : Application
     public ElementTheme GlobalElementTheme { get; set; }
 
     MainWindow? _mainWindow;
+#pragma warning disable CS8603 // Possible null reference return.
     public MainWindow MainWindow => _mainWindow;
+#pragma warning restore CS8603 // Possible null reference return.
     public WindowManager WindowManager { get; } = new WindowManager();
 
     public static App CurrentApp => (App)Application.Current;

--- a/src/DLSS Swapper.csproj
+++ b/src/DLSS Swapper.csproj
@@ -401,7 +401,7 @@
     <PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="System.Management" Version="10.0.5" />
-    <PackageReference Include="ValveKeyValue" Version="0.51.0.482" />
+    <PackageReference Include="ValveKeyValue" Version="0.60.0.494" />
     <PackageReference Include="WinUI.TableView" Version="1.4.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <Manifest Include="$(ApplicationManifest)" />

--- a/src/DLSS Swapper.csproj
+++ b/src/DLSS Swapper.csproj
@@ -118,6 +118,7 @@
     <None Remove="UserControls\ManuallyAddGameControl.xaml" />
     <None Remove="UserControls\MultipleDLLsFoundControl.xaml" />
     <None Remove="UserControls\NewDLLsControl.xaml" />
+    <None Remove="UserControls\NGXModelImporter.xaml" />
   </ItemGroup>
 
   <ItemGroup>
@@ -321,6 +322,9 @@
             <Pack>True</Pack>
             <PackagePath>\</PackagePath>
         </None>
+        <Page Update="UserControls\NGXModelImporter.xaml">
+          <Generator>MSBuild:Compile</Generator>
+        </Page>
         <Page Update="UserControls\GameHistoryControl.xaml">
           <Generator>MSBuild:Compile</Generator>
         </Page>
@@ -398,6 +402,7 @@
     <PackageReference Include="System.Drawing.Common" Version="10.0.5" />
     <PackageReference Include="System.Management" Version="10.0.5" />
     <PackageReference Include="ValveKeyValue" Version="0.51.0.482" />
+    <PackageReference Include="WinUI.TableView" Version="1.4.0" />
     <PackageReference Include="YamlDotNet" Version="16.3.0" />
     <Manifest Include="$(ApplicationManifest)" />
   </ItemGroup>

--- a/src/Data/DLLManager.cs
+++ b/src/Data/DLLManager.cs
@@ -1112,14 +1112,22 @@ internal class DLLManager
         return false;
     }
 
-    internal DLLImportResult ImportDll(string filePath, string? zippedDllFullName = null)
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="filePath">Path of the DLL you wish to import.</param>
+    /// <param name="zippedDllFullName"></param>
+    /// <param name="overrideFileName">Override the filename for importing NGX models that are not .dlls yet.</param>
+    /// <returns></returns>
+
+    internal DLLImportResult ImportDll(string filePath, string? zippedDllFullName = null, string? overrideFileName = null)
     {
         if (ImportedManifest is null)
         {
             return DLLImportResult.FromFail(zippedDllFullName ?? filePath, ResourceHelper.GetString("DllManager_ImportFeatureDisabled"));
         }
 
-        var fileName = Path.GetFileName(filePath);
+        var fileName = overrideFileName ?? Path.GetFileName(filePath);
 
         ObservableCollection<DLLRecord>? recordList = null;
         List<DLLRecord>? importedRecordList = null;
@@ -1389,4 +1397,5 @@ internal class DLLManager
             entry.ExtractToFile(dllRecord.LocalRecord.ExpectedPath, true);
         }
     }
+
 }

--- a/src/Data/DLLRecordModelTranslationProperties.cs
+++ b/src/Data/DLLRecordModelTranslationProperties.cs
@@ -22,7 +22,7 @@ public class DLLRecordModelTranslationProperties : LocalizedViewModelBase
     public string CancelText => ResourceHelper.GetString("General_Cancel");
 
     [TranslationProperty]
-    public string DownloadingText => ResourceHelper.GetString("DllRecord_Downloading");
+    public string DownloadingText => ResourceHelper.GetString("General_Downloading");
 
     [TranslationProperty]
     public string RequiresDownloadText => ResourceHelper.GetString("DllRecord_RequiresDownload");

--- a/src/Data/DLLRecordModelTranslationProperties.cs
+++ b/src/Data/DLLRecordModelTranslationProperties.cs
@@ -13,7 +13,7 @@ public class DLLRecordModelTranslationProperties : LocalizedViewModelBase
     public string DeleteText => ResourceHelper.GetString("General_Delete");
 
     [TranslationProperty]
-    public string DownloadText => ResourceHelper.GetString("DllRecord_Download");
+    public string DownloadText => ResourceHelper.GetString("General_Download");
 
     [TranslationProperty]
     public string DownloadErrorText => ResourceHelper.GetString("DllRecord_DownloadError");

--- a/src/Data/NVIDIA/ListBucketResult.cs
+++ b/src/Data/NVIDIA/ListBucketResult.cs
@@ -1,0 +1,14 @@
+namespace DLSS_Swapper.Data.NVIDIA;
+
+[System.Xml.Serialization.XmlRootAttribute(Namespace = "http://s3.amazonaws.com/doc/2006-03-01/", IsNullable = false)]
+public class ListBucketResult
+{
+    public string Name { get; set; } = string.Empty;
+    public string Prefix { get; set; } = string.Empty;
+    public string Marker { get; set; } = string.Empty;
+    public int MaxKeys { get; set; }
+    public bool IsTruncated { get; set; }
+
+    [System.Xml.Serialization.XmlElementAttribute("Contents")]
+    public ListBucketResultContents[] Contents { get; set; } = [];
+}

--- a/src/Data/NVIDIA/ListBucketResultContents.cs
+++ b/src/Data/NVIDIA/ListBucketResultContents.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DLSS_Swapper.Data.NVIDIA;
+
+public class ListBucketResultContents
+{
+    public string Key { get; set; } = string.Empty;
+    public DateTime LastModified { get; set; } = DateTime.MinValue;
+    public string ETag { get; set; } = string.Empty;
+    public string ChecksumAlgorithm { get; set; } = string.Empty;
+    public string ChecksumType { get; set; } = string.Empty;
+    public ulong Size { get; set; }
+    public string StorageClass { get; set; } = string.Empty;
+}

--- a/src/Data/NVIDIA/NGXModel.cs
+++ b/src/Data/NVIDIA/NGXModel.cs
@@ -7,13 +7,16 @@ public class NGXModel
     public string FilePath { get; }
     public Version Version { get; }
     public GameAssetType GameAssetType { get; }
-
+    public long Size { get; }
     public string GameAssetTypeString => DLLManager.Instance.GetAssetTypeName(GameAssetType);
+    public string ETag { get; }
 
-    public NGXModel(string filePath, Version version, GameAssetType gameAssetType)
+    public NGXModel(string filePath, Version version, GameAssetType gameAssetType, long size, string eTag)
     {
         FilePath = filePath;
         Version = version;
         GameAssetType = gameAssetType;
+        Size = size;
+        ETag = eTag;
     }
 }

--- a/src/Data/NVIDIA/NGXModel.cs
+++ b/src/Data/NVIDIA/NGXModel.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace DLSS_Swapper.Data.NVIDIA;
+
+public class NGXModel
+{
+    public string FilePath { get; }
+    public Version Version { get; }
+    public GameAssetType GameAssetType { get; }
+
+    public string GameAssetTypeString => DLLManager.Instance.GetAssetTypeName(GameAssetType);
+
+    public NGXModel(string filePath, Version version, GameAssetType gameAssetType)
+    {
+        FilePath = filePath;
+        Version = version;
+        GameAssetType = gameAssetType;
+    }
+}

--- a/src/Data/NVIDIA/NGXModelRow.cs
+++ b/src/Data/NVIDIA/NGXModelRow.cs
@@ -1,0 +1,19 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace DLSS_Swapper.Data.NVIDIA;
+
+public partial class NGXModelRow : ObservableObject
+{
+    public NGXModel NGXModel { get; }
+
+    [ObservableProperty]
+    public partial bool IsChecked { get; set; } = false;
+
+    // TODO: Disable rows for already imported content?
+    public bool IsEnabled { get; } = true;
+
+    public NGXModelRow(NGXModel ngxModel)
+    {
+        NGXModel = ngxModel;
+    }
+}

--- a/src/Data/NVIDIA/NGXModelRow.cs
+++ b/src/Data/NVIDIA/NGXModelRow.cs
@@ -9,8 +9,11 @@ public partial class NGXModelRow : ObservableObject
     [ObservableProperty]
     public partial bool IsChecked { get; set; } = false;
 
-    // TODO: Disable rows for already imported content?
-    public bool IsEnabled { get; } = true;
+    [ObservableProperty]
+    public partial bool IsEnabled { get; set; } = true;
+
+    [ObservableProperty]
+    public partial string StatusMessage { get; set; } = string.Empty;
 
     public NGXModelRow(NGXModel ngxModel)
     {

--- a/src/Extensions/VersionExtensions.cs
+++ b/src/Extensions/VersionExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace DLSS_Swapper.Extensions;
+
+internal static class VersionExtensions
+{
+    internal static ulong GetVersionNumber(this Version version)
+    {
+        return ((ulong)version.Major << 48) +
+                ((ulong)version.Minor << 32) +
+                ((ulong)version.Build << 16) +
+                ((ulong)version.Revision);
+    }
+}

--- a/src/Helpers/FileDownloader.cs
+++ b/src/Helpers/FileDownloader.cs
@@ -183,6 +183,11 @@ public partial class FileDownloader : ObservableObject
         {
             throw;
         }
+        catch (HttpRequestException err) when (err.StatusCode == HttpStatusCode.NotFound)
+        {
+            Logger.Error(err, $"{LogPrefix} could not download {_url}");
+            throw;
+        }
         catch (Exception err)
         {
             Logger.Error(err, $"{LogPrefix} could not download {_url}");

--- a/src/Helpers/FileDownloader.cs
+++ b/src/Helpers/FileDownloader.cs
@@ -190,7 +190,10 @@ public partial class FileDownloader : ObservableObject
         }
         catch (Exception err)
         {
-            Logger.Error(err, $"{LogPrefix} could not download {_url}");
+            if (cancellationToken.IsCancellationRequested == false)
+            {
+                Logger.Error(err, $"{LogPrefix} could not download {_url}");
+            }
             throw;
         }
         finally

--- a/src/Helpers/NVAPIHelper.cs
+++ b/src/Helpers/NVAPIHelper.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using DLSS_Swapper.Data;
 using DLSS_Swapper.Data.DLSS;
+using DLSS_Swapper.Data.NVIDIA;
 using DLSS_Swapper.UserControls;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -672,5 +673,72 @@ internal partial class NVAPIHelper : ObservableObject
         {
             FileSystemHelper.OpenFolderInExplorer(Logger.LogDirectory);
         }
+    }
+
+    public List<NGXModel> GetNGXModels()
+    {
+    
+        var ngxModelsPath = Path.Combine(Environment.ExpandEnvironmentVariables("%ProgramData%"), "NVIDIA", "NGX", "models");
+        if (Directory.Exists(ngxModelsPath) == false)
+        {
+            return [];
+        }
+
+        var ngxModels = new List<NGXModel>();
+
+        var dlssPath = Path.Combine(ngxModelsPath, "dlss", "versions");
+        var dlssdPath = Path.Combine(ngxModelsPath, "dlssd", "versions");
+        var dlssgPath = Path.Combine(ngxModelsPath, "dlssg", "versions");
+
+        // Local function so we can handle all DLSS at once.
+        List<NGXModel> LocalNgxModelSearch(string path, GameAssetType gameAssetType, string[] validProductNames)
+        {
+            var tempList = new List<NGXModel>();
+
+            if (Directory.Exists(path))
+            {
+                var binFiles = Directory.GetFiles(path, "*.bin", SearchOption.AllDirectories);
+                foreach (var binFile in binFiles)
+                {
+                    var fileVersionInfo = FileVersionInfo.GetVersionInfo(binFile);
+                    var isTrusted = WinTrust.VerifyEmbeddedSignature(binFile);
+
+                    var isValid = true;
+
+                    // Ignore a game if it is not trusted.
+                    if (isTrusted == false)
+                    {
+                        isValid = false;
+                    }
+
+                    // Ignore games where we don't know if it is the correct product name
+                    if (validProductNames.Contains(fileVersionInfo.ProductName) == false)
+                    {
+                        isValid = false;
+                    }
+
+                    // If everything matches OR AllowUntrusted is on allow the game
+                    if (isValid || Settings.Instance.AllowUntrusted)
+                    {
+                        ngxModels.Add(new NGXModel(binFile, new Version(fileVersionInfo.FileMajorPart, fileVersionInfo.FileMinorPart, fileVersionInfo.FileBuildPart, fileVersionInfo.FilePrivatePart), gameAssetType));
+                    }
+                }
+            }
+
+            return tempList;
+        }
+
+        ngxModels.AddRange(LocalNgxModelSearch(dlssPath, GameAssetType.DLSS, [
+            "NVIDIA Deep Learning SuperSampling",
+            "NGX DL SuperSampling"
+        ]));
+        ngxModels.AddRange(LocalNgxModelSearch(dlssdPath, GameAssetType.DLSS_D, [
+            "NVIDIA DLSS Ray Reconstruction"
+        ]));
+        ngxModels.AddRange(LocalNgxModelSearch(dlssgPath, GameAssetType.DLSS_G, [
+            "NVIDIA DLSS-G MFGLW"
+        ]));
+
+        return ngxModels;
     }
 }

--- a/src/Helpers/NVAPIHelper.cs
+++ b/src/Helpers/NVAPIHelper.cs
@@ -5,6 +5,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Security.Cryptography;
 using System.Text.Json;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -677,7 +678,6 @@ internal partial class NVAPIHelper : ObservableObject
 
     public List<NGXModel> GetNGXModels()
     {
-    
         var ngxModelsPath = Path.Combine(Environment.ExpandEnvironmentVariables("%ProgramData%"), "NVIDIA", "NGX", "models");
         if (Directory.Exists(ngxModelsPath) == false)
         {
@@ -700,6 +700,7 @@ internal partial class NVAPIHelper : ObservableObject
                 var binFiles = Directory.GetFiles(path, "*.bin", SearchOption.AllDirectories);
                 foreach (var binFile in binFiles)
                 {
+                    var fileInfo = new FileInfo(binFile);
                     var fileVersionInfo = FileVersionInfo.GetVersionInfo(binFile);
                     var isTrusted = WinTrust.VerifyEmbeddedSignature(binFile);
 
@@ -720,7 +721,7 @@ internal partial class NVAPIHelper : ObservableObject
                     // If everything matches OR AllowUntrusted is on allow the game
                     if (isValid || Settings.Instance.AllowUntrusted)
                     {
-                        ngxModels.Add(new NGXModel(binFile, new Version(fileVersionInfo.FileMajorPart, fileVersionInfo.FileMinorPart, fileVersionInfo.FileBuildPart, fileVersionInfo.FilePrivatePart), gameAssetType));
+                        ngxModels.Add(new NGXModel(binFile, new Version(fileVersionInfo.FileMajorPart, fileVersionInfo.FileMinorPart, fileVersionInfo.FileBuildPart, fileVersionInfo.FilePrivatePart), gameAssetType , fileInfo.Length, string.Empty));
                     }
                 }
             }
@@ -740,5 +741,102 @@ internal partial class NVAPIHelper : ObservableObject
         ]));
 
         return ngxModels;
+    }
+
+    long FactorOf1MB(long fileSize, int numParts)
+    {
+        var fileSizePerPart = fileSize / (double)numParts;
+        var modulo1MB = fileSizePerPart % 1048576;
+        return (long)(fileSizePerPart + 1048576 - modulo1MB);
+    }
+
+    public bool ValidateNVIDIAOtaHash(Stream stream, string hash)
+    {
+        if (string.IsNullOrWhiteSpace(hash))
+        {
+            return false;
+        }
+
+        stream.Position = 0;
+
+        if (hash.Contains('-'))
+        {
+            var hashStringParts = hash.Trim('"').Split('-');
+            if (hashStringParts.Length != 2)
+            {
+                Logger.Error("Could not find number of hash parts.");
+                return false;
+            }
+
+            if (Int32.TryParse(hashStringParts[1], out var parts) == false)
+            {
+                return false;
+            }
+
+            var fileSize = stream.Length;
+
+            // Via https://teppen.io/2018/10/23/aws_s3_verify_etags/
+            var partSizesToTry = new long[] {
+                8388608, // aws_cli/boto3
+			    15728640, // s3cmd
+			    FactorOf1MB(fileSize, parts) // Used by many clients to upload large files
+		    };
+
+            foreach (var partSize in partSizesToTry)
+            {
+                var partHashes = new List<byte[]>(parts);
+                var buffer = new byte[partSize];
+
+                stream.Position = 0;
+
+                for (var i = 0; i < parts; ++i)
+                {
+                    Array.Clear(buffer);
+                    var bytesRead = stream.Read(buffer, 0, buffer.Length);
+                    using (var md5 = MD5.Create())
+                    {
+                        var computedHash = md5.ComputeHash(buffer, 0, bytesRead);
+                        //Log.Information($"{i} - {Convert.ToHexStringLower(computedHash)}");
+                        partHashes.Add(computedHash);
+                    }
+                }
+
+                // Concatenate all raw MD5 hashes onto one long byte array
+                int totalBytes = partHashes.Count * 16;
+                var allHashes = new byte[totalBytes];
+                int offset = 0;
+                foreach (var partHash in partHashes)
+                {
+                    Buffer.BlockCopy(partHash, 0, allHashes, offset, partHash.Length);
+                    offset += partHash.Length;
+                }
+
+                // MD5 the final large byte array
+                using (var md5 = MD5.Create())
+                {
+                    var finalHash = md5.ComputeHash(allHashes);
+                    var hashStringWithQuotes = $"\"{Convert.ToHexStringLower(finalHash)}-{partHashes.Count}\"";
+                    var valid = string.Equals(hashStringWithQuotes, hash);
+                    if (valid)
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        else
+        {
+            stream.Position = 0;
+
+            using (var md5 = MD5.Create())
+            {
+                var computedHash = md5.ComputeHash(stream);
+                var hashStringWithQuotes = $"\"{Convert.ToHexStringLower(computedHash).ToLowerInvariant()}\"";
+                var valid = string.Equals(hashStringWithQuotes, hash);
+                return valid;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Helpers/ResourceHelper.cs
+++ b/src/Helpers/ResourceHelper.cs
@@ -101,7 +101,16 @@ public class ResourceHelper
         Debug.WriteLine($"Translation not found: {resourceName}");
 
         // If not we fallback to the original language.
-        return _resourceLoader.GetString(resourceName);
+        var fallbackString = _resourceLoader.GetString(resourceName);
+
+#if DEBUG
+        if (string.IsNullOrWhiteSpace(fallbackString))
+        {
+            Debug.WriteLine($"Translation not found: {resourceName}");
+            Debugger.Break();
+        }
+#endif
+        return fallbackString;
     }
 
     public static string GetFormattedResourceTemplate(string templateResourceName, params object[] args)

--- a/src/Pages/LibraryPage.xaml
+++ b/src/Pages/LibraryPage.xaml
@@ -44,11 +44,23 @@
             </StackPanel>
 
             <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                <AppBarButton HorizontalAlignment="Right"  Label="{x:Bind ViewModel.TranslationProperties.ImportText, Mode=OneWay}" Command="{x:Bind ViewModel.ImportCommand}">
+
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.ImportText, Mode=OneWay}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xE8B5;"  />
                     </AppBarButton.Content>
+                    <AppBarButton.Flyout>
+                        <MenuFlyout>
+                            <MenuFlyoutItem Text="Single DLL file" Command="{x:Bind ViewModel.ImportCommand}" />
+                            <MenuFlyoutItem Text="Single zip file" Command="{x:Bind ViewModel.ImportCommand}" />
+                            <MenuFlyoutSubItem Text="NVIDIA">
+                                <MenuFlyoutItem Text="From driver" Command="{x:Bind ViewModel.ImportFromNVIDIADriverCommand}" />
+                                <MenuFlyoutItem Text="Download from OTA server" Command="{x:Bind ViewModel.ImportFromNVIDIAServerCommand}" />
+                            </MenuFlyoutSubItem>
+                        </MenuFlyout>
+                    </AppBarButton.Flyout>
                 </AppBarButton>
+
                 <AppBarButton HorizontalAlignment="Right" Label="{x:Bind ViewModel.TranslationProperties.ExportAllText, Mode=OneWay}" Command="{x:Bind ViewModel.ExportAllCommand}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xEDE1;" />

--- a/src/Pages/LibraryPage.xaml
+++ b/src/Pages/LibraryPage.xaml
@@ -51,11 +51,10 @@
                     </AppBarButton.Content>
                     <AppBarButton.Flyout>
                         <MenuFlyout>
-                            <MenuFlyoutItem Text="Single DLL file" Command="{x:Bind ViewModel.ImportCommand}" />
-                            <MenuFlyoutItem Text="Single zip file" Command="{x:Bind ViewModel.ImportCommand}" />
+                            <MenuFlyoutItem Text="{x:Bind ViewModel.TranslationProperties.ImportFromLocalFilesText, Mode=OneWay}" Command="{x:Bind ViewModel.ImportCommand}" />
                             <MenuFlyoutSubItem Text="NVIDIA">
-                                <MenuFlyoutItem Text="From driver" Command="{x:Bind ViewModel.ImportFromNVIDIADriverCommand}" />
-                                <MenuFlyoutItem Text="Download from OTA server" Command="{x:Bind ViewModel.ImportFromNVIDIAServerCommand}" />
+                                <MenuFlyoutItem Text="{x:Bind ViewModel.TranslationProperties.ImportFromDriverText, Mode=OneWay}" Command="{x:Bind ViewModel.ImportFromNVIDIADriverCommand}" />
+                                <MenuFlyoutItem Text="{x:Bind ViewModel.TranslationProperties.ImportFromDownloadServerText, Mode=OneWay}" Command="{x:Bind ViewModel.ImportFromNVIDIAServerCommand}" />
                             </MenuFlyoutSubItem>
                         </MenuFlyout>
                     </AppBarButton.Flyout>

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -1001,6 +1001,8 @@ public partial class LibraryPageModel : ObservableObject
                 }
             });
 
+            await DLLManager.Instance.SaveImportedManifestJsonAsync();
+
             importingDialog.Hide();
 
             var completeDialog = new EasyContentDialog(_libraryPage.XamlRoot)

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -914,37 +914,53 @@ public partial class LibraryPageModel : ObservableObject
             filesProgressBar.Value = 0;
             filesProgressBar.Maximum = modelsToImport.Count;
 
-            var progress = new Progress<int>();
-            progress.ProgressChanged += (s, i) =>
-            {
-                filesProgressBar.Value = i;
-                progressRun.Text = i.ToString(CultureInfo.CurrentCulture);
-            };
-
             _ = importingDialog.ShowAsync();
+
+            var successCount = 0;
+            var failedCount = 0;
 
             await Task.Run(() => {
                 for (var i = 0; i < modelsToImport.Count; ++i)
                 {
                     try
                     {
-                        DLLManager.Instance.ImportDll(modelsToImport[i].FilePath, overrideFileName: DLLManager.DllNameForGameAssetType(modelsToImport[i].GameAssetType));
+                        var didImport = DLLManager.Instance.ImportDll(modelsToImport[i].FilePath, overrideFileName: DLLManager.DllNameForGameAssetType(modelsToImport[i].GameAssetType));
+                        if (didImport.Success)
+                        {
+                            ++successCount;
+                        }
+                        else
+                        {
+                            ++failedCount;
+                        }
                     }
                     catch (Exception ex)
                     {
+                        ++failedCount;
                         Logger.Error(ex, "Error importing NGX model.");
                     }
                     finally
                     {
-                        if (progress is IProgress<int> iProgress)
+                        App.CurrentApp.RunOnUIThread(() =>
                         {
-                            iProgress.Report(i + 1);
-                        }
+                            filesProgressBar.Value = i;
+                            progressRun.Text = i.ToString(CultureInfo.CurrentCulture);
+                        });
                     }
                 }
             });
 
             importingDialog.Hide();
+
+            var completeDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = $"{ResourceHelper.GetString("General_Success")}: {successCount}\n{ResourceHelper.GetString("General_Failed")}: {failedCount}",
+                CloseButtonText = ResourceHelper.GetString("General_Close"),
+            };
+            completeDialog.ShowAsync();
+
         }
     }
 

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -7,8 +7,10 @@ using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml.Serialization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
@@ -917,10 +919,369 @@ public partial class LibraryPageModel : ObservableObject
     }
 
 
+    [GeneratedRegex(@"^d6e9b45e-d4f6-4a84-a460-bf61decae3e8\/(?<asset_type>dlss|dlssg|dlssd)\/versions\/(?<version_packed>\d*)\/files\/160_E658700\.bin$", RegexOptions.IgnoreCase)]
+    private static partial Regex IsNGXModelWeCanUse();
+
     [RelayCommand]
     async Task ImportFromNVIDIAServerAsync()
     {
-        
+        var loadingProgressRing = new ProgressRing()
+        {
+            IsIndeterminate = true
+        };
+        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = "Fetching File List",
+            Content = loadingProgressRing,
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+        };
+        using var cancellationTokenSource = new CancellationTokenSource();
+        loadingDialog.CloseButtonClick += (ContentDialog sender, ContentDialogButtonClickEventArgs args) => {
+            cancellationTokenSource.Cancel();
+        };
+
+        _ = loadingDialog.ShowAsync();
+
+        var ngxOtaUrl = "https://ngx.download.nvidia.com";
+        var xmlDownloader = new FileDownloader(ngxOtaUrl);
+
+        var availableModels = new List<NGXModel>();
+
+        using (var memoryStream = new MemoryStream())
+        {
+            try
+            {
+                var didDownload = await xmlDownloader.DownloadFileToStreamAsync(memoryStream, cancellationTokenSource.Token);
+                if (didDownload == false)
+                {
+                    throw new Exception("Could not download xml stream.");
+                }
+
+                memoryStream.Position = 0;
+
+                var serializer = new XmlSerializer(typeof(ListBucketResult));
+                var listBucketResult = serializer.Deserialize(memoryStream) as ListBucketResult;
+
+                if (listBucketResult is null)
+                {
+                    throw new Exception("ListBucketResult was null.");
+                }
+
+
+                foreach (var content in listBucketResult.Contents)
+                {
+                    if (content is null || content.Size == 0)
+                    {
+                        continue;
+                    }
+
+                    // We only give the option of 160_E658700.bin. Other files do exist.
+                    // 160 is from NV_GPU_ARCHITECTURE_ID of Turing GPUs. But it appears everyone has this for DLSS files.
+                    // As for what E658700, no idea.
+                    // https://github.com/SimonMacer/AnWave/issues/52#issuecomment-3025720063
+                    // https://docs.nvidia.com/nvapi/group__gpu.html
+                    if (content.Key.EndsWith("files/160_E658700.bin") == false)
+                    {
+                        continue;
+                    }
+
+                    var match = IsNGXModelWeCanUse().Match(content.Key);
+                    if (match.Success == false)
+                    {
+                        continue;
+                    }
+
+                    GameAssetType? gameAssetType = match.Groups["asset_type"].Value switch
+                    {
+                        "dlss" => GameAssetType.DLSS,
+                        "dlssd" => GameAssetType.DLSS_D,
+                        "dlssg" => GameAssetType.DLSS_G,
+                        _ => null,
+                    };
+
+
+                    if (gameAssetType == null)
+                    {
+                        continue;
+                    }
+
+                    if (Int32.TryParse(match.Groups["version_packed"].ValueSpan, out var versionInt) == false)
+                    {
+                        Logger.Error($"Could not convert {match.Groups["version_packed"].Value} to a version number.");
+                        continue;
+                    }
+
+                    var major = (versionInt >> 16) & 0xFFFF;
+                    var minor = (versionInt >> 8) & 0xFF;
+                    var build = versionInt & 0xFF;
+                    var version = new Version(major, minor, build, 0);
+
+                    availableModels.Add(new NGXModel($"{ngxOtaUrl}/{content.Key}", version, gameAssetType.Value, (long)content.Size, content.ETag));
+                }
+
+            }
+            catch (TaskCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+            {
+                // NOOP: User cancelled
+                return;
+            }
+            catch (Exception ex)
+            {
+                Logger.Error(ex);
+
+                loadingDialog.Hide();
+
+                var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+                {
+                    Title = ResourceHelper.GetString("General_Error"),
+                    Content = "Unable to import from NVIDIA servers. Please try again later or check for DLSS Swapper updates.",
+                    CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+                };
+                await errorDialog.ShowAsync();
+                return;
+            }
+        }
+
+
+        if (availableModels.Count == 0)
+        {
+            loadingDialog.Hide();
+            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                Content = "Unable to fetch file list from NVIDIA servers. Please try again later or check for DLSS Swapper updates.",
+                CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+
+        var ngxModelImporter = new NGXModelImporter(availableModels);
+
+        foreach (var modelRow in ngxModelImporter.ViewModel.Models)
+        {
+            var versionNumber = modelRow.NGXModel.Version.GetVersionNumber();
+
+            var existingRecordsToTest = new List<DLLRecord>();
+
+            if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS)
+            {
+                var existingDLLRecords = DLLManager.Instance.DLSSRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                existingRecordsToTest.AddRange(existingDLLRecords);
+            }
+            else if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS_D)
+            {
+                var existingDLLRecords = DLLManager.Instance.DLSSDRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                existingRecordsToTest.AddRange(existingDLLRecords);
+            }
+            else if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS_G)
+            {
+                var existingDLLRecords = DLLManager.Instance.DLSSGRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                existingRecordsToTest.AddRange(existingDLLRecords);
+            }
+
+            foreach (var existingRecordToTest in existingRecordsToTest)
+            {
+                try
+                {
+                    if (File.Exists(existingRecordToTest?.LocalRecord?.ExpectedPath))
+                    {
+                        using (var fileStream = File.OpenRead(existingRecordToTest.LocalRecord.ExpectedPath))
+                        {
+                            var isValid = NVAPIHelper.Instance.ValidateNVIDIAOtaHash(fileStream, modelRow.NGXModel.ETag);
+                            if (isValid)
+                            {
+                                modelRow.IsEnabled = false;
+                                modelRow.StatusMessage = "Already downloaded";
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Logger.Error(ex);
+                }
+            }
+        }
+
+        loadingDialog.Hide();
+
+        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = "Download from NVIDIA",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = ngxModelImporter,
+            PrimaryButtonText = ResourceHelper.GetString("General_Download"),
+            CloseButtonText = ResourceHelper.GetString("General_Close"),
+        };
+        dialog.Resources["ContentDialogMinWidth"] = 700;
+        var result = await dialog.ShowAsync();
+
+        if (result != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        var modelsToDownload = ngxModelImporter.ViewModel.Models.Where(x => x.IsChecked).ToList();
+        if (modelsToDownload.Count == 0)
+        {
+            return;
+        }
+
+
+        var totalFilesProgressBar = new ProgressBar()
+        {
+            IsIndeterminate = false,
+            Value = 0,
+            Maximum = modelsToDownload.Count,
+        };
+        var totalFilesTextBlock = new TextBlock()
+        {
+            Text = string.Empty,
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        totalFilesTextBlock.Inlines.Add(new Run() { Text = "Downloaded: " });
+        var totalFilesProgressRun = new Run() { Text = "0" };
+        totalFilesTextBlock.Inlines.Add(totalFilesProgressRun);
+
+
+        var currentFileProgressBar = new ProgressBar()
+        {
+            IsIndeterminate = false,
+            Value = 0,
+            Maximum = 1,
+            Margin = new Thickness(0, 8, 0, 0),
+        };
+        var currentFileTextBlock = new TextBlock()
+        {
+            Text = string.Empty,
+            HorizontalAlignment = HorizontalAlignment.Left,
+        };
+        currentFileTextBlock.Inlines.Add(new Run() { Text = "Progress: " });
+        var currentFileProgressRun = new Run() { Text = "0" };
+        currentFileTextBlock.Inlines.Add(currentFileProgressRun);
+
+        var progressStackPanel = new StackPanel()
+        {
+            Spacing = 16,
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                totalFilesProgressBar,
+                totalFilesTextBlock,
+                currentFileProgressBar,
+                currentFileTextBlock,
+            }
+        };
+
+        var downloadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("General_Downloading"),
+            Content = progressStackPanel,
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+        };
+
+        downloadingDialog.CloseButtonClick += (ContentDialog sender, ContentDialogButtonClickEventArgs args) => {
+            cancellationTokenSource.Cancel();
+        };
+
+        _ = downloadingDialog.ShowAsync();
+
+        var successCount = 0;
+        var failCount = 0;
+
+        await Task.Run(async () => {
+            for (var i = 0; i < modelsToDownload.Count; ++i)
+            {
+                if (cancellationTokenSource.IsCancellationRequested)
+                {
+                    return;
+                }
+
+                App.CurrentApp.RunOnUIThread(() =>
+                {
+                    currentFileProgressBar.Value = 0;
+                });
+
+                try
+                {
+                    var tempFileName = $"{Guid.NewGuid().ToString("D")}.tmp";
+                    var tempFilePath = Path.Combine(Storage.GetTemp(), tempFileName);
+
+                    var didDownload = false;
+                    using (var fileStream = File.Create(tempFilePath))
+                    {
+                        var fileDownloader = new FileDownloader(modelsToDownload[i].NGXModel.FilePath);
+                        didDownload = await fileDownloader.DownloadFileToStreamAsync(fileStream, cancellationTokenSource.Token, progressCallback: (DownloadedBytes, TotalBytesToDownload, Percent) =>
+                        {
+                            App.CurrentApp.RunOnUIThread(() =>
+                            {
+                                var smallPercent = Percent / 100.0;
+                                currentFileProgressBar.Value = smallPercent;
+                                currentFileProgressRun.Text = smallPercent.ToString("P", CultureInfo.CurrentCulture);
+                            });
+                        });
+                    }
+
+                    if (didDownload)
+                    {
+                        var didImport = DLLManager.Instance.ImportDll(tempFilePath, overrideFileName: DLLManager.DllNameForGameAssetType(modelsToDownload[i].NGXModel.GameAssetType));
+                        if (didImport.Success)
+                        {
+                            ++successCount;
+                        }
+                        else
+                        {
+                            ++failCount;
+                        }
+                    }
+                    else
+                    {
+                        ++failCount;
+                    }
+                }
+                catch (TaskCanceledException) when (cancellationTokenSource.IsCancellationRequested)
+                {
+                    // NOOP
+                }
+                catch (Exception ex)
+                {
+                    ++failCount;
+                    Logger.Error(ex, "Error downloading or importing NGX model.");
+                }
+                finally
+                {
+                    App.CurrentApp.RunOnUIThread(() =>
+                    {
+                        totalFilesProgressBar.Value += 1;
+                        totalFilesProgressRun.Text = totalFilesProgressBar.Value.ToString(CultureInfo.CurrentCulture);
+                    });
+                }
+            }
+        });
+
+
+        if (cancellationTokenSource.IsCancellationRequested == false)
+        {
+            await DLLManager.Instance.SaveImportedManifestJsonAsync();
+
+            downloadingDialog.Hide();
+
+            var completeDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = "Download from NVIDIA",
+                DefaultButton = ContentDialogButton.Close,
+                Content = $"Success: {successCount}\nFailed: {failCount}",
+                CloseButtonText = ResourceHelper.GetString("General_Close"),
+            };
+            await completeDialog.ShowAsync();
+
+        }
+        else
+        {
+            downloadingDialog.Hide();
+        }
     }
 
     [RelayCommand]

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -13,6 +13,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.WinUI;
 using DLSS_Swapper.Data;
+using DLSS_Swapper.Data.NVIDIA;
 using DLSS_Swapper.Extensions;
 using DLSS_Swapper.Helpers;
 using DLSS_Swapper.UserControls;
@@ -800,6 +801,126 @@ public partial class LibraryPageModel : ObservableObject
             Content = new ImportDLLSummaryControl(importResults),
         };
         await dialog.ShowAsync();
+    }
+
+    [RelayCommand]
+    async Task ImportFromNVIDIADriver()
+    {
+        var models = NVAPIHelper.Instance.GetNGXModels();
+
+        if (models.Count == 0)
+        {
+            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                Content = "Could not import locate any DLLs in the driver to import.",
+                CloseButtonText = ResourceHelper.GetString("General_Close"),
+            };
+            await errorDialog.ShowAsync();
+            return;
+        }
+                
+        var ngxModelImporter = new NGXModelImporter(models);
+        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = "Import from NVIDIA driver",
+            DefaultButton = ContentDialogButton.Primary,
+            Content = ngxModelImporter,
+            PrimaryButtonText = ResourceHelper.GetString("General_Import"),
+            CloseButtonText = ResourceHelper.GetString("General_Close"),
+        };
+        dialog.Resources["ContentDialogMinWidth"] = 700;
+        var result = await dialog.ShowAsync();
+        if (result == ContentDialogResult.Primary)
+        {
+            var modelsToImport = new List<NGXModel>();
+            foreach (var modelRow in ngxModelImporter.ViewModel.Models)
+            {
+                if (modelRow.IsChecked == true)
+                {
+                    modelsToImport.Add(modelRow.NGXModel);
+                }
+            }
+
+            if (modelsToImport.Count == 0)
+            {
+                return;
+            }
+
+
+            var filesProgressBar = new ProgressBar()
+            {
+                IsIndeterminate = true
+            };
+            var progressTextBlock = new TextBlock()
+            {
+                Text = string.Empty,
+                HorizontalAlignment = HorizontalAlignment.Left,
+            };
+            progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ImportedDLLs") });
+            var progressRun = new Run() { Text = "0" };
+            progressTextBlock.Inlines.Add(progressRun);
+            var progressStackPanel = new StackPanel()
+            {
+                Spacing = 16,
+                Orientation = Orientation.Vertical,
+                Children =
+                {
+                    filesProgressBar,
+                    progressTextBlock,
+                }
+            };
+
+
+            var importingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("LibraryPage_Importing"),
+                Content = progressStackPanel,
+            };
+
+            filesProgressBar.IsIndeterminate = false;
+            filesProgressBar.Value = 0;
+            filesProgressBar.Maximum = modelsToImport.Count;
+
+            var progress = new Progress<int>();
+            progress.ProgressChanged += (s, i) =>
+            {
+                filesProgressBar.Value = i;
+                progressRun.Text = i.ToString(CultureInfo.CurrentCulture);
+            };
+
+            _ = importingDialog.ShowAsync();
+
+            await Task.Run(() => {
+                for (var i = 0; i < modelsToImport.Count; ++i)
+                {
+                    try
+                    {
+                        DLLManager.Instance.ImportDll(modelsToImport[i].FilePath, overrideFileName: DLLManager.DllNameForGameAssetType(modelsToImport[i].GameAssetType));
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex, "Error importing NGX model.");
+                    }
+                    finally
+                    {
+                        if (progress is IProgress<int> iProgress)
+                        {
+                            iProgress.Report(i + 1);
+                        }
+                    }
+                }
+            });
+
+            importingDialog.Hide();
+        }
+    }
+
+
+    [RelayCommand]
+    async Task ImportFromNVIDIAServerAsync()
+    {
+        
     }
 
     [RelayCommand]

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -808,9 +808,37 @@ public partial class LibraryPageModel : ObservableObject
     }
 
     [RelayCommand]
-    async Task ImportFromNVIDIADriver()
+    async Task ImportFromNVIDIADriverAsync()
     {
-        var models = NVAPIHelper.Instance.GetNGXModels();
+        var loadingProgressRing = new ProgressRing()
+        {
+            IsIndeterminate = true
+        };
+        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
+            Content = loadingProgressRing,
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+        };
+        using var cancellationTokenSource = new CancellationTokenSource();
+        loadingDialog.CloseButtonClick += (ContentDialog sender, ContentDialogButtonClickEventArgs args) => {
+            cancellationTokenSource.Cancel();
+        };
+
+        _ = loadingDialog.ShowAsync();
+
+        var models = new List<NGXModel>();
+        await Task.Run(() =>
+        {
+            models.AddRange(NVAPIHelper.Instance.GetNGXModels());
+        });
+
+        loadingDialog.Hide();
+
+        if (cancellationTokenSource.IsCancellationRequested)
+        {
+            return;
+        }
 
         if (models.Count == 0)
         {

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -813,7 +813,7 @@ public partial class LibraryPageModel : ObservableObject
             var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
-                Content = "Could not import locate any DLLs in the driver to import.",
+                Content = "Could not locate any DLLs in the driver to import.",
                 CloseButtonText = ResourceHelper.GetString("General_Close"),
             };
             await errorDialog.ShowAsync();

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -23,13 +23,12 @@ using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
-using Windows.UI.Text;
 
 namespace DLSS_Swapper.Pages;
 
 public partial class LibraryPageModel : ObservableObject
 {
-    LibraryPage libraryPage;
+    readonly LibraryPage _libraryPage;
 
     internal ObservableCollection<DLLRecord>? SelectedLibraryList { get; private set; }
 
@@ -43,9 +42,9 @@ public partial class LibraryPageModel : ObservableObject
 
     public LibraryPageModel(LibraryPage libraryPage)
     {
-        this.libraryPage = libraryPage;
+        _libraryPage = libraryPage;
 
-        var upscalerSelectorBar = libraryPage.FindChild("UpscalerSelectorBar") as SelectorBar;
+        var upscalerSelectorBar = _libraryPage.FindChild("UpscalerSelectorBar") as SelectorBar;
         if (upscalerSelectorBar is not null)
         {
             // NOTE: DLL type
@@ -68,7 +67,7 @@ public partial class LibraryPageModel : ObservableObject
 
     void OnLanguageChanged()
     {
-        var upscalerSelectorBar = libraryPage.FindChild("UpscalerSelectorBar") as SelectorBar;
+        var upscalerSelectorBar = _libraryPage.FindChild("UpscalerSelectorBar") as SelectorBar;
         if (upscalerSelectorBar is null)
         {
             return;
@@ -113,7 +112,7 @@ public partial class LibraryPageModel : ObservableObject
         }
         else
         {
-            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -144,7 +143,7 @@ public partial class LibraryPageModel : ObservableObject
 
         if (allDllRecords.Count == 0)
         {
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
                 DefaultButton = ContentDialogButton.Close,
@@ -181,7 +180,7 @@ public partial class LibraryPageModel : ObservableObject
         };
 
         var str = ResourceHelper.GetString("LibraryPage_Exporting");
-        var exportingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var exportingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_Exporting"),
             Content = progressStackPanel,
@@ -248,7 +247,7 @@ public partial class LibraryPageModel : ObservableObject
             {
                 exportingDialog.Hide();
 
-                var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+                var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
                 {
                     Title = ResourceHelper.GetString("General_Error"),
                     CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -279,7 +278,7 @@ public partial class LibraryPageModel : ObservableObject
 
                 if (exportError is null)
                 {
-                    var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+                    var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
                     {
                         CloseButtonText = ResourceHelper.GetString("General_Okay"),
                         DefaultButton = ContentDialogButton.Close,
@@ -317,7 +316,7 @@ public partial class LibraryPageModel : ObservableObject
             Logger.Error(err);
 
             // If the fullExpectedPath does not exist, or there was an error writing it.
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -377,7 +376,7 @@ public partial class LibraryPageModel : ObservableObject
     {
         if (DLLManager.Instance.ImportedManifest is null)
         {
-            var couldNotImportDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var couldNotImportDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_CouldNotLoadImportedDlls"),
                 DefaultButton = ContentDialogButton.Close,
@@ -390,7 +389,7 @@ public partial class LibraryPageModel : ObservableObject
 
         if (Settings.Instance.HasShownWarning == false)
         {
-            var warningDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var warningDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Warning"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -448,7 +447,7 @@ public partial class LibraryPageModel : ObservableObject
             }
         };
 
-        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var loadingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_Importing"),
             // I would like this to be a progress ring but for some reason the ring will not show.
@@ -797,7 +796,7 @@ public partial class LibraryPageModel : ObservableObject
 
         loadingDialog.Hide();
 
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             CloseButtonText = ResourceHelper.GetString("General_Okay"),
             DefaultButton = ContentDialogButton.Close,
@@ -814,7 +813,7 @@ public partial class LibraryPageModel : ObservableObject
         {
             IsIndeterminate = true
         };
-        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var loadingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
             Content = loadingProgressRing,
@@ -842,7 +841,7 @@ public partial class LibraryPageModel : ObservableObject
 
         if (models.Count == 0)
         {
-            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 Content = ResourceHelper.GetString("LibraryPage_CouldNotImportFromDriver"),
@@ -853,7 +852,7 @@ public partial class LibraryPageModel : ObservableObject
         }
                 
         var ngxModelImporter = new NGXModelImporter(models);
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
             DefaultButton = ContentDialogButton.Primary,
@@ -904,7 +903,7 @@ public partial class LibraryPageModel : ObservableObject
             };
 
 
-            var importingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var importingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_Importing"),
                 Content = progressStackPanel,
@@ -952,14 +951,14 @@ public partial class LibraryPageModel : ObservableObject
 
             importingDialog.Hide();
 
-            var completeDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var completeDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
                 DefaultButton = ContentDialogButton.Close,
                 Content = $"{ResourceHelper.GetString("General_Success")}: {successCount}\n{ResourceHelper.GetString("General_Failed")}: {failedCount}",
                 CloseButtonText = ResourceHelper.GetString("General_Close"),
             };
-            completeDialog.ShowAsync();
+            await completeDialog.ShowAsync();
 
         }
     }
@@ -975,7 +974,7 @@ public partial class LibraryPageModel : ObservableObject
         {
             IsIndeterminate = true
         };
-        var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var loadingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_FetchingFileList"),
             Content = loadingProgressRing,
@@ -1077,7 +1076,7 @@ public partial class LibraryPageModel : ObservableObject
 
                 loadingDialog.Hide();
 
-                var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+                var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
                 {
                     Title = ResourceHelper.GetString("General_Error"),
                     Content = ResourceHelper.GetString("LibraryPage_Error_NVIDIA_Importing"),
@@ -1092,7 +1091,7 @@ public partial class LibraryPageModel : ObservableObject
         if (availableModels.Count == 0)
         {
             loadingDialog.Hide();
-            var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 Content = ResourceHelper.GetString("LibraryPage_Error_NVIDIA_Downloading"),
@@ -1153,7 +1152,7 @@ public partial class LibraryPageModel : ObservableObject
 
         loadingDialog.Hide();
 
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_DownloadFromNVIDIA"),
             DefaultButton = ContentDialogButton.Primary,
@@ -1221,7 +1220,7 @@ public partial class LibraryPageModel : ObservableObject
             }
         };
 
-        var downloadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var downloadingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("General_Downloading"),
             Content = progressStackPanel,
@@ -1314,7 +1313,7 @@ public partial class LibraryPageModel : ObservableObject
 
             downloadingDialog.Hide();
 
-            var completeDialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var completeDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_DownloadFromNVIDIA"),
                 DefaultButton = ContentDialogButton.Close,
@@ -1341,7 +1340,7 @@ public partial class LibraryPageModel : ObservableObject
         }
 
         var assetTypeName = DLLManager.Instance.GetAssetTypeName(record.AssetType);
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_DeleteDll"),
             PrimaryButtonText = ResourceHelper.GetString("General_Delete"),
@@ -1369,7 +1368,7 @@ public partial class LibraryPageModel : ObservableObject
             }
             else
             {
-                var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
+                var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
                 {
                     Title = ResourceHelper.GetString("General_Error"),
                     CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1387,7 +1386,7 @@ public partial class LibraryPageModel : ObservableObject
         var result = await record.DownloadAsync();
         if (result.Success is false && result.Cancelled is false)
         {
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1414,7 +1413,7 @@ public partial class LibraryPageModel : ObservableObject
             return;
         }
 
-        var exportingDialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var exportingDialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_Exporting"),
             // I would like this to be a progress ring but for some reason the ring will not show.
@@ -1473,7 +1472,7 @@ public partial class LibraryPageModel : ObservableObject
 
             exportingDialog.Hide();
 
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Success"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1488,7 +1487,7 @@ public partial class LibraryPageModel : ObservableObject
             Logger.Error(err);
 
             // If the fullExpectedPath does not exist, or there was an error writing it.
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1502,7 +1501,7 @@ public partial class LibraryPageModel : ObservableObject
     [RelayCommand]
     async Task ShowDownloadErrorAsync(DLLRecord record)
     {
-        var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+        var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("General_Error"),
             CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1549,7 +1548,7 @@ public partial class LibraryPageModel : ObservableObject
 
         if (startedDownloads == 0)
         {
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_NoNewDLLs_Title"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),
@@ -1560,7 +1559,7 @@ public partial class LibraryPageModel : ObservableObject
         }
         else
         {
-            var dialog = new EasyContentDialog(libraryPage.XamlRoot)
+            var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("LibraryPage_DownloadsStarted_Title"),
                 CloseButtonText = ResourceHelper.GetString("General_Okay"),

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -832,15 +832,17 @@ public partial class LibraryPageModel : ObservableObject
             models.AddRange(NVAPIHelper.Instance.GetNGXModels());
         });
 
-        loadingDialog.Hide();
-
         if (cancellationTokenSource.IsCancellationRequested)
         {
+
+            loadingDialog.Hide();
             return;
         }
 
         if (models.Count == 0)
         {
+
+            loadingDialog.Hide();
             var errorDialog = new EasyContentDialog(_libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
@@ -852,6 +854,56 @@ public partial class LibraryPageModel : ObservableObject
         }
                 
         var ngxModelImporter = new NGXModelImporter(models);
+
+        await Task.Run(() =>
+        {
+            foreach (var modelRow in ngxModelImporter.ViewModel.Models)
+            {
+                var versionNumber = modelRow.NGXModel.Version.GetVersionNumber();
+
+                var existingRecordsToTest = new List<DLLRecord>();
+
+                if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS)
+                {
+                    var existingDLLRecords = DLLManager.Instance.DLSSRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                    existingRecordsToTest.AddRange(existingDLLRecords);
+                }
+                else if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS_D)
+                {
+                    var existingDLLRecords = DLLManager.Instance.DLSSDRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                    existingRecordsToTest.AddRange(existingDLLRecords);
+                }
+                else if (modelRow.NGXModel.GameAssetType == GameAssetType.DLSS_G)
+                {
+                    var existingDLLRecords = DLLManager.Instance.DLSSGRecords.Where(x => x.VersionNumber == versionNumber && x.LocalRecord is not null && x.LocalRecord.IsDownloaded);
+                    existingRecordsToTest.AddRange(existingDLLRecords);
+                }
+
+                foreach (var existingRecordToTest in existingRecordsToTest)
+                {
+                    try
+                    {
+                        using (var fileStream = File.OpenRead(modelRow.NGXModel.FilePath))
+                        {
+                            var md5Hash = fileStream.GetMD5Hash();
+                            if (string.Equals(md5Hash, existingRecordToTest.MD5Hash))
+                            {
+                                modelRow.IsEnabled = false;
+                                modelRow.StatusMessage = ResourceHelper.GetString("LibraryPage_AlreadyDownloaded");
+                                break;
+                            }
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Error(ex);
+                    }
+                }
+            }
+        });
+
+        loadingDialog.Hide();
+
         var dialog = new EasyContentDialog(_libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -92,7 +92,7 @@ public partial class LibraryPageModel : ObservableObject
         }
     }
 
-    [RelayCommand()]
+    [RelayCommand]
     async Task RefreshAsync()
     {
         IsRefreshing = true;

--- a/src/Pages/LibraryPageModel.cs
+++ b/src/Pages/LibraryPageModel.cs
@@ -19,9 +19,11 @@ using DLSS_Swapper.Data.NVIDIA;
 using DLSS_Swapper.Extensions;
 using DLSS_Swapper.Helpers;
 using DLSS_Swapper.UserControls;
+using Microsoft.UI.Text;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Documents;
+using Windows.UI.Text;
 
 namespace DLSS_Swapper.Pages;
 
@@ -164,7 +166,7 @@ public partial class LibraryPageModel : ObservableObject
             Text = string.Empty,
             HorizontalAlignment = HorizontalAlignment.Left,
         };
-        progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ExportedDLLs") });
+        progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ExportedDLLs"), FontWeight = FontWeights.Bold });
         var progressRun = new Run() { Text = "0" };
         progressTextBlock.Inlines.Add(progressRun);
         var progressStackPanel = new StackPanel()
@@ -178,7 +180,7 @@ public partial class LibraryPageModel : ObservableObject
             }
         };
 
-
+        var str = ResourceHelper.GetString("LibraryPage_Exporting");
         var exportingDialog = new EasyContentDialog(libraryPage.XamlRoot)
         {
             Title = ResourceHelper.GetString("LibraryPage_Exporting"),
@@ -431,7 +433,7 @@ public partial class LibraryPageModel : ObservableObject
             Text = string.Empty,
             HorizontalAlignment = HorizontalAlignment.Left,
         };
-        progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ProcessedDlls") });
+        progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ProcessedDlls"), FontWeight = FontWeights.Bold });
         var progressRun = new Run() { Text = "0" };
         progressTextBlock.Inlines.Add(progressRun);
         var progressStackPanel = new StackPanel()
@@ -815,7 +817,7 @@ public partial class LibraryPageModel : ObservableObject
             var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
-                Content = "Could not locate any DLLs in the driver to import.",
+                Content = ResourceHelper.GetString("LibraryPage_CouldNotImportFromDriver"),
                 CloseButtonText = ResourceHelper.GetString("General_Close"),
             };
             await errorDialog.ShowAsync();
@@ -825,7 +827,7 @@ public partial class LibraryPageModel : ObservableObject
         var ngxModelImporter = new NGXModelImporter(models);
         var dialog = new EasyContentDialog(libraryPage.XamlRoot)
         {
-            Title = "Import from NVIDIA driver",
+            Title = ResourceHelper.GetString("LibraryPage_ImportFromNVIDIADriver"),
             DefaultButton = ContentDialogButton.Primary,
             Content = ngxModelImporter,
             PrimaryButtonText = ResourceHelper.GetString("General_Import"),
@@ -859,7 +861,7 @@ public partial class LibraryPageModel : ObservableObject
                 Text = string.Empty,
                 HorizontalAlignment = HorizontalAlignment.Left,
             };
-            progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ImportedDLLs") });
+            progressTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ImportedDLLs"), FontWeight = FontWeights.Bold });
             var progressRun = new Run() { Text = "0" };
             progressTextBlock.Inlines.Add(progressRun);
             var progressStackPanel = new StackPanel()
@@ -931,7 +933,7 @@ public partial class LibraryPageModel : ObservableObject
         };
         var loadingDialog = new EasyContentDialog(libraryPage.XamlRoot)
         {
-            Title = "Fetching File List",
+            Title = ResourceHelper.GetString("LibraryPage_FetchingFileList"),
             Content = loadingProgressRing,
             CloseButtonText = ResourceHelper.GetString("General_Cancel"),
         };
@@ -1034,7 +1036,7 @@ public partial class LibraryPageModel : ObservableObject
                 var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
                 {
                     Title = ResourceHelper.GetString("General_Error"),
-                    Content = "Unable to import from NVIDIA servers. Please try again later or check for DLSS Swapper updates.",
+                    Content = ResourceHelper.GetString("LibraryPage_Error_NVIDIA_Importing"),
                     CloseButtonText = ResourceHelper.GetString("General_Cancel"),
                 };
                 await errorDialog.ShowAsync();
@@ -1049,7 +1051,7 @@ public partial class LibraryPageModel : ObservableObject
             var errorDialog = new EasyContentDialog(libraryPage.XamlRoot)
             {
                 Title = ResourceHelper.GetString("General_Error"),
-                Content = "Unable to fetch file list from NVIDIA servers. Please try again later or check for DLSS Swapper updates.",
+                Content = ResourceHelper.GetString("LibraryPage_Error_NVIDIA_Downloading"),
                 CloseButtonText = ResourceHelper.GetString("General_Cancel"),
             };
             await errorDialog.ShowAsync();
@@ -1092,7 +1094,7 @@ public partial class LibraryPageModel : ObservableObject
                             if (isValid)
                             {
                                 modelRow.IsEnabled = false;
-                                modelRow.StatusMessage = "Already downloaded";
+                                modelRow.StatusMessage = ResourceHelper.GetString("LibraryPage_AlreadyDownloaded");
                                 break;
                             }
                         }
@@ -1109,7 +1111,7 @@ public partial class LibraryPageModel : ObservableObject
 
         var dialog = new EasyContentDialog(libraryPage.XamlRoot)
         {
-            Title = "Download from NVIDIA",
+            Title = ResourceHelper.GetString("LibraryPage_DownloadFromNVIDIA"),
             DefaultButton = ContentDialogButton.Primary,
             Content = ngxModelImporter,
             PrimaryButtonText = ResourceHelper.GetString("General_Download"),
@@ -1141,7 +1143,7 @@ public partial class LibraryPageModel : ObservableObject
             Text = string.Empty,
             HorizontalAlignment = HorizontalAlignment.Left,
         };
-        totalFilesTextBlock.Inlines.Add(new Run() { Text = "Downloaded: " });
+        totalFilesTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_DownloadedCount"), FontWeight = FontWeights.Bold });
         var totalFilesProgressRun = new Run() { Text = "0" };
         totalFilesTextBlock.Inlines.Add(totalFilesProgressRun);
 
@@ -1158,7 +1160,7 @@ public partial class LibraryPageModel : ObservableObject
             Text = string.Empty,
             HorizontalAlignment = HorizontalAlignment.Left,
         };
-        currentFileTextBlock.Inlines.Add(new Run() { Text = "Progress: " });
+        currentFileTextBlock.Inlines.Add(new Run() { Text = ResourceHelper.GetString("LibraryPage_ProgressPercent"), FontWeight = FontWeights.Bold });
         var currentFileProgressRun = new Run() { Text = "0" };
         currentFileTextBlock.Inlines.Add(currentFileProgressRun);
 
@@ -1270,11 +1272,12 @@ public partial class LibraryPageModel : ObservableObject
 
             var completeDialog = new EasyContentDialog(libraryPage.XamlRoot)
             {
-                Title = "Download from NVIDIA",
+                Title = ResourceHelper.GetString("LibraryPage_DownloadFromNVIDIA"),
                 DefaultButton = ContentDialogButton.Close,
-                Content = $"Success: {successCount}\nFailed: {failCount}",
+                Content = $"{ResourceHelper.GetString("General_Success")}: {successCount}\n{ResourceHelper.GetString("General_Failed")}: {failCount}",
                 CloseButtonText = ResourceHelper.GetString("General_Close"),
             };
+
             await completeDialog.ShowAsync();
 
         }

--- a/src/Pages/LibraryPageModelTranslationProperties.cs
+++ b/src/Pages/LibraryPageModelTranslationProperties.cs
@@ -1,6 +1,7 @@
 using DLSS_Swapper.Attributes;
 using DLSS_Swapper.Helpers;
 using DLSS_Swapper.Interfaces;
+using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace DLSS_Swapper.Pages;
 
@@ -29,4 +30,14 @@ public class LibraryPageModelTranslationProperties : LocalizedViewModelBase
 
     [TranslationProperty]
     public string PageTitle => ResourceHelper.GetString("LibraryPage_Title");
+
+    [TranslationProperty]
+    public string ImportFromLocalFilesText => ResourceHelper.GetString("LibraryPage_ImportFrom_LocalFiles");
+
+    [TranslationProperty]
+    public string ImportFromDriverText => ResourceHelper.GetString("LibraryPage_ImportFrom_Driver");
+
+    [TranslationProperty]
+    public string ImportFromDownloadServerText => ResourceHelper.GetString("LibraryPage_ImportFrom_DownloadFromServer");
+
 }

--- a/src/Pages/LibraryPageModelTranslationProperties.cs
+++ b/src/Pages/LibraryPageModelTranslationProperties.cs
@@ -1,7 +1,6 @@
 using DLSS_Swapper.Attributes;
 using DLSS_Swapper.Helpers;
 using DLSS_Swapper.Interfaces;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace DLSS_Swapper.Pages;
 

--- a/src/Translations/ar-SA/Resources.resw
+++ b/src/Translations/ar-SA/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>تعذّر تنزيل {0} DLL. يُرجى المحاولة لاحقًا أو التحقق من السجلات لمعرفة سبب فشل التنزيل.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>تنزيل</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطأ في التنزيل</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>جارٍ التنزيل</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>تم الاستيراد</value>
@@ -451,6 +445,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>لا تُظهر هذا مرة أخرى</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>تنزيل</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>جارٍ التنزيل</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>خطأ</value>

--- a/src/Translations/ar-SA/Resources.resw
+++ b/src/Translations/ar-SA/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطأ في التنزيل</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>جارٍ التنزيل</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ar-SA/Resources.resw
+++ b/src/Translations/ar-SA/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>تعذّر تنزيل {0} DLL. يُرجى المحاولة لاحقًا أو التحقق من السجلات لمعرفة سبب فشل التنزيل.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>تنزيل</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
@@ -681,7 +681,7 @@
     <value>تحديث manifest</value>
   </data>
   <data name="MainWindow_NoteForMultiplayerGames_Message" xml:space="preserve">
-    <value>على الرغم من أن تبديل إصدارات DLSS لا يُعتبر غشًا، إلا أن بعض أنظمة مكافحة الغش قد لا تقبل بذلك إذا كانت الملفات في مجلد لعبتك تختلف عن الملفات الأصلية التي تم توزيعها مع اللعبة. 
+    <value>على الرغم من أن تبديل إصدارات DLSS لا يُعتبر غشًا، إلا أن بعض أنظمة مكافحة الغش قد لا تقبل بذلك إذا كانت الملفات في مجلد لعبتك تختلف عن الملفات الأصلية التي تم توزيعها مع اللعبة.
 لذلك نوصي بالحذر عند استخدام هذه الأداة في العاب الاونلاين (متعددة اللاعبين).</value>
   </data>
   <data name="MainWindow_NoteForMultiplayerGames_Title" xml:space="preserve">

--- a/src/Translations/ar-SY/Resources.resw
+++ b/src/Translations/ar-SY/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>فشل في تنزيل {0} DLL، يرجى إعادة المحاولة لاحقاً أو مراجعة ملفات السجل لمعرفة سبب الفشل.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>تحميل</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/ar-SY/Resources.resw
+++ b/src/Translations/ar-SY/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطأ في التحميل</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>يتم التحميل</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ar-SY/Resources.resw
+++ b/src/Translations/ar-SY/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>فشل في تنزيل {0} DLL، يرجى إعادة المحاولة لاحقاً أو مراجعة ملفات السجل لمعرفة سبب الفشل.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>تحميل</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطأ في التحميل</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>يتم التحميل</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>تم الاستيراد</value>
@@ -442,6 +436,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>لا تقوم بإظهارها مرة أخرى</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>تحميل</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>يتم التحميل</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>خطاً</value>

--- a/src/Translations/ca-ES/Resources.resw
+++ b/src/Translations/ca-ES/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Error de descàrrega</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Descarregant</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ca-ES/Resources.resw
+++ b/src/Translations/ca-ES/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>No s'ha pogut descarregar la DLL {0}. Si us plau, torneu-ho a provar més tard o consulteu els registres per veure per què ha fallat la descàrrega.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Descarrega</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/ca-ES/Resources.resw
+++ b/src/Translations/ca-ES/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>No s'ha pogut descarregar la DLL {0}. Si us plau, torneu-ho a provar més tard o consulteu els registres per veure per què ha fallat la descàrrega.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Descarrega</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Error de descàrrega</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Descarregant</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importat</value>
@@ -464,6 +458,12 @@ Si heu marcat aquestes opcions i el vostre joc encara no apareix, pot haver-hi u
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>No tornis a mostrar</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Descarrega</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Descarregant</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Error</value>

--- a/src/Translations/cs-CZ/Resources.resw
+++ b/src/Translations/cs-CZ/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Chyba stahování</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Stahuji</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/cs-CZ/Resources.resw
+++ b/src/Translations/cs-CZ/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Nebylo možné stáhnout {0} DLL, prosím zkuste to znovu později, nebo zkontrolujte protokol ke zjištění proč stahování selhalo.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Stáhnout</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Chyba stahování</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Stahuji</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importováno</value>
@@ -482,6 +476,12 @@ Pokud jste tyto možnosti zkontrolovali a hra se stále nezobrazuje, může se j
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Znovu nezobrazovat</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Stáhnout</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Stahuji</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Chyba</value>

--- a/src/Translations/cs-CZ/Resources.resw
+++ b/src/Translations/cs-CZ/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Nebylo možné stáhnout {0} DLL, prosím zkuste to znovu později, nebo zkontrolujte protokol ke zjištění proč stahování selhalo.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Stáhnout</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Die {0} DLL konnte nicht heruntergeladen werden. Bitte versuche es später noch einmal oder schau in der Log Datei nach, warum der Download nicht geklappt hat.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Herunterladen</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Die {0} DLL konnte nicht heruntergeladen werden. Bitte versuche es später noch einmal oder schau in der Log Datei nach, warum der Download nicht geklappt hat.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Herunterladen</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Fehler beim herunterladen</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Lädt herunter</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importiert</value>
@@ -482,6 +476,12 @@ Wenn Du alles überprüft hast und dein Spiel taucht immer noch nicht auf, liegt
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Nicht mehr anzeigen</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Herunterladen</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Lädt herunter</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Fehler</value>

--- a/src/Translations/de-DE/Resources.resw
+++ b/src/Translations/de-DE/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Fehler beim herunterladen</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Lädt herunter</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -148,7 +148,7 @@
     <value>Could not download {0} DLL, please try again later or check your logs to see why the download failed.</value>
     <comment>{0} will be the DLL type (eg. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Download</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
@@ -490,6 +490,14 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="General_Delete" xml:space="preserve">
     <value>Delete</value>
+  </data>
+  <data name="General_Status" xml:space="preserve">
+    <value>Status</value>
+  </data>
+
+
+  <data name="General_Size" xml:space="preserve">
+    <value>Size</value>
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Don't show again</value>

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -672,6 +672,20 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="GitHubUpdater_UpdateAvailable" xml:space="preserve">
     <value>Update Available</value>
   </data>
+
+
+  <data name="LibraryPage_ImportFrom_LocalFiles" xml:space="preserve">
+    <value>From local files</value>
+  </data>
+  <data name="LibraryPage_ImportFrom_Driver" xml:space="preserve">
+    <value>From driver</value>
+  </data>
+  <data name="LibraryPage_ImportFrom_DownloadFromServer" xml:space="preserve">
+    <value>Download from server</value>
+  </data>
+
+
+
   <data name="LibraryPage_AlreadyDownloaded" xml:space="preserve">
     <value>Already downloaded.</value>
   </data>
@@ -714,11 +728,11 @@ If you have checked these and your game is still not showing up there may be a b
 
 
 
-  <data name="LibraryPage_Exportingx" xml:space="preserve">
+  <data name="LibraryPage_Exporting" xml:space="preserve">
     <value>Exporting</value>
   </data>
 
-  <data name="LibraryPage_Importingx" xml:space="preserve">
+  <data name="LibraryPage_Importing" xml:space="preserve">
     <value>Importing</value>
   </data>
 
@@ -1132,4 +1146,34 @@ Because of this we recommend using caution for multiplayer games.</value>
   <data name="TranslationToolboxPage_WindowTitle" xml:space="preserve">
     <value>Translation Toolbox</value>
   </data>
+
+
+  <data name="LibraryPage_CouldNotImportFromDriver" xml:space="preserve">
+    <value>Could not locate any DLLs to import from the driver</value>
+  </data>
+  <data name="LibraryPage_ImportFromNVIDIADriver" xml:space="preserve">
+    <value>Import from NVIDIA driver</value>
+  </data>
+  <data name="LibraryPage_FetchingFileList" xml:space="preserve">
+    <value>Fetching File List</value>
+  </data>
+  <data name="LibraryPage_Error_NVIDIA_Importing" xml:space="preserve">
+    <value>Unable to import from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
+  </data>
+  <data name="LibraryPage_Error_NVIDIA_Downloading" xml:space="preserve">
+    <value>Unable to fetch file list from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
+  </data>
+
+
+  <data name="LibraryPage_DownloadFromNVIDIA" xml:space="preserve">
+    <value>Download from NVIDIA</value>
+  </data>
+  <data name="LibraryPage_DownloadedCount" xml:space="preserve">
+    <value>Downloaded: </value>
+  </data>
+  <data name="LibraryPage_ProgressPercent" xml:space="preserve">
+    <value>Progress: </value>
+  </data>
+
+
 </root>

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -148,14 +148,8 @@
     <value>Could not download {0} DLL, please try again later or check your logs to see why the download failed.</value>
     <comment>{0} will be the DLL type (eg. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Download</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Download Error</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Downloading</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Imported</value>
@@ -491,16 +485,14 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="General_Delete" xml:space="preserve">
     <value>Delete</value>
   </data>
-  <data name="General_Status" xml:space="preserve">
-    <value>Status</value>
-  </data>
-
-
-  <data name="General_Size" xml:space="preserve">
-    <value>Size</value>
-  </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Don't show again</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Downloading</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Error</value>
@@ -638,8 +630,14 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="General_Search" xml:space="preserve">
     <value>Search</value>
   </data>
+  <data name="General_Size" xml:space="preserve">
+    <value>Size</value>
+  </data>
   <data name="General_Sorry" xml:space="preserve">
     <value>Sorry</value>
+  </data>
+  <data name="General_Status" xml:space="preserve">
+    <value>Status</value>
   </data>
   <data name="General_Success" xml:space="preserve">
     <value>Success</value>
@@ -672,22 +670,11 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="GitHubUpdater_UpdateAvailable" xml:space="preserve">
     <value>Update Available</value>
   </data>
-
-
-  <data name="LibraryPage_ImportFrom_LocalFiles" xml:space="preserve">
-    <value>From local files</value>
-  </data>
-  <data name="LibraryPage_ImportFrom_Driver" xml:space="preserve">
-    <value>From driver</value>
-  </data>
-  <data name="LibraryPage_ImportFrom_DownloadFromServer" xml:space="preserve">
-    <value>Download from server</value>
-  </data>
-
-
-
   <data name="LibraryPage_AlreadyDownloaded" xml:space="preserve">
     <value>Already downloaded.</value>
+  </data>
+  <data name="LibraryPage_CouldNotImportFromDriver" xml:space="preserve">
+    <value>Could not locate any DLLs to import from the driver</value>
   </data>
   <data name="LibraryPage_CouldNotLoadImportedDlls" xml:space="preserve">
     <value>Could not load imported DLLs</value>
@@ -725,17 +712,12 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="LibraryPage_DllRecordInfo_Label" xml:space="preserve">
     <value>Label</value>
   </data>
-
-
-
-  <data name="LibraryPage_Exporting" xml:space="preserve">
-    <value>Exporting</value>
+  <data name="LibraryPage_DownloadedCount" xml:space="preserve">
+    <value>Downloaded: </value>
   </data>
-
-  <data name="LibraryPage_Importing" xml:space="preserve">
-    <value>Importing</value>
+  <data name="LibraryPage_DownloadFromNVIDIA" xml:space="preserve">
+    <value>Download from NVIDIA</value>
   </data>
-
   <data name="LibraryPage_DownloadLatest" xml:space="preserve">
     <value>Download Latest</value>
   </data>
@@ -746,11 +728,14 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="LibraryPage_DownloadsStarted_Title" xml:space="preserve">
     <value>Downloads started</value>
   </data>
+  <data name="LibraryPage_Error_NVIDIA_Downloading" xml:space="preserve">
+    <value>Unable to fetch file list from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
+  </data>
+  <data name="LibraryPage_Error_NVIDIA_Importing" xml:space="preserve">
+    <value>Unable to import from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
+  </data>
   <data name="LibraryPage_ExportedDLLs" xml:space="preserve">
     <value>Exported DLLs: </value>
-  </data>
-  <data name="LibraryPage_ImportedDLLs" xml:space="preserve">
-    <value>Imported DLLs: </value>
   </data>
   <data name="LibraryPage_ExportedDLLsCount_Message" xml:space="preserve">
     <value>Exported {0} DLLs.</value>
@@ -760,6 +745,12 @@ If you have checked these and your game is still not showing up there may be a b
     <value>Exported DLL {0}.</value>
     <comment>Leave 0 as it is and use safe string format</comment>
   </data>
+  <data name="LibraryPage_Exporting" xml:space="preserve">
+    <value>Exporting</value>
+  </data>
+  <data name="LibraryPage_FetchingFileList" xml:space="preserve">
+    <value>Fetching File List</value>
+  </data>
   <data name="LibraryPage_FileNotFound" xml:space="preserve">
     <value>File not found.</value>
   </data>
@@ -768,6 +759,24 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="LibraryPage_ImportedAsExistingRecord" xml:space="preserve">
     <value>Imported as existing DLL record.</value>
+  </data>
+  <data name="LibraryPage_ImportedDLLs" xml:space="preserve">
+    <value>Imported DLLs: </value>
+  </data>
+  <data name="LibraryPage_ImportFrom_DownloadFromServer" xml:space="preserve">
+    <value>Download from server</value>
+  </data>
+  <data name="LibraryPage_ImportFrom_Driver" xml:space="preserve">
+    <value>From driver</value>
+  </data>
+  <data name="LibraryPage_ImportFrom_LocalFiles" xml:space="preserve">
+    <value>From local files</value>
+  </data>
+  <data name="LibraryPage_ImportFromNVIDIADriver" xml:space="preserve">
+    <value>Import from NVIDIA driver</value>
+  </data>
+  <data name="LibraryPage_Importing" xml:space="preserve">
+    <value>Importing</value>
   </data>
   <data name="LibraryPage_Importing" xml:space="preserve">
     <value>Importing</value>
@@ -793,6 +802,9 @@ Only import dlls from sources you trust.</value>
   </data>
   <data name="LibraryPage_ProcessedDlls" xml:space="preserve">
     <value>Processed DLLs: </value>
+  </data>
+  <data name="LibraryPage_ProgressPercent" xml:space="preserve">
+    <value>Progress: </value>
   </data>
   <data name="LibraryPage_Title" xml:space="preserve">
     <value>Library</value>
@@ -1146,34 +1158,4 @@ Because of this we recommend using caution for multiplayer games.</value>
   <data name="TranslationToolboxPage_WindowTitle" xml:space="preserve">
     <value>Translation Toolbox</value>
   </data>
-
-
-  <data name="LibraryPage_CouldNotImportFromDriver" xml:space="preserve">
-    <value>Could not locate any DLLs to import from the driver</value>
-  </data>
-  <data name="LibraryPage_ImportFromNVIDIADriver" xml:space="preserve">
-    <value>Import from NVIDIA driver</value>
-  </data>
-  <data name="LibraryPage_FetchingFileList" xml:space="preserve">
-    <value>Fetching File List</value>
-  </data>
-  <data name="LibraryPage_Error_NVIDIA_Importing" xml:space="preserve">
-    <value>Unable to import from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
-  </data>
-  <data name="LibraryPage_Error_NVIDIA_Downloading" xml:space="preserve">
-    <value>Unable to fetch file list from NVIDIA servers. Please try again later or check for DLSS Swapper updates.</value>
-  </data>
-
-
-  <data name="LibraryPage_DownloadFromNVIDIA" xml:space="preserve">
-    <value>Download from NVIDIA</value>
-  </data>
-  <data name="LibraryPage_DownloadedCount" xml:space="preserve">
-    <value>Downloaded: </value>
-  </data>
-  <data name="LibraryPage_ProgressPercent" xml:space="preserve">
-    <value>Progress: </value>
-  </data>
-
-
 </root>

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -154,7 +154,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Download Error</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Downloading</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -703,6 +703,17 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="LibraryPage_DllRecordInfo_Label" xml:space="preserve">
     <value>Label</value>
   </data>
+
+
+
+  <data name="LibraryPage_Exportingx" xml:space="preserve">
+    <value>Exporting</value>
+  </data>
+
+  <data name="LibraryPage_Importingx" xml:space="preserve">
+    <value>Importing</value>
+  </data>
+
   <data name="LibraryPage_DownloadLatest" xml:space="preserve">
     <value>Download Latest</value>
   </data>
@@ -715,6 +726,9 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="LibraryPage_ExportedDLLs" xml:space="preserve">
     <value>Exported DLLs: </value>
+  </data>
+  <data name="LibraryPage_ImportedDLLs" xml:space="preserve">
+    <value>Imported DLLs: </value>
   </data>
   <data name="LibraryPage_ExportedDLLsCount_Message" xml:space="preserve">
     <value>Exported {0} DLLs.</value>

--- a/src/Translations/es-ES/Resources.resw
+++ b/src/Translations/es-ES/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>No se pudo descargar el DLL {0}, por favor inténtalo de nuevo más tarde o revisa tus registros para ver por qué falló la descarga.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Descargar</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/es-ES/Resources.resw
+++ b/src/Translations/es-ES/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Error de Descarga</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Descargando</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/es-ES/Resources.resw
+++ b/src/Translations/es-ES/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>No se pudo descargar el DLL {0}, por favor inténtalo de nuevo más tarde o revisa tus registros para ver por qué falló la descarga.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Descargar</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Error de Descarga</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Descargando</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importado</value>
@@ -464,6 +458,12 @@ Si has comprobado esto y tu juego sigue sin aparecer, puede que haya un error. A
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>No volver a mostrar</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Descargar</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Descargando</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Error</value>

--- a/src/Translations/fa-IR/Resources.resw
+++ b/src/Translations/fa-IR/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Could not download {0} DLL, please try again later or check your logs to see why the download failed.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>دانلود</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/fa-IR/Resources.resw
+++ b/src/Translations/fa-IR/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Could not download {0} DLL, please try again later or check your logs to see why the download failed.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>دانلود</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطای دانلود</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>در حال دانلود</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>وارد شد</value>
@@ -483,6 +477,12 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>دیگر نشان نده</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>دانلود</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>در حال دانلود</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>خطا</value>

--- a/src/Translations/fa-IR/Resources.resw
+++ b/src/Translations/fa-IR/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>خطای دانلود</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>در حال دانلود</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/fi-FI/Resources.resw
+++ b/src/Translations/fi-FI/Resources.resw
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
-    Microsoft ResX Schema 
-    
+  <!--
+    Microsoft ResX Schema
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -148,7 +148,7 @@
     <value>Ei voitu ladata {0} DLL-tiedostoa. Yritä myöhemmin uudelleen tai tarkista lokit saadaksesi tietää miksi lataus epäonnistui.</value>
     <comment>{0} will be the DLL type (eg. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Lataa</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/fi-FI/Resources.resw
+++ b/src/Translations/fi-FI/Resources.resw
@@ -154,7 +154,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Latausvirhe</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Ladataan</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/fi-FI/Resources.resw
+++ b/src/Translations/fi-FI/Resources.resw
@@ -148,14 +148,8 @@
     <value>Ei voitu ladata {0} DLL-tiedostoa. Yritä myöhemmin uudelleen tai tarkista lokit saadaksesi tietää miksi lataus epäonnistui.</value>
     <comment>{0} will be the DLL type (eg. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Lataa</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Latausvirhe</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Ladataan</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Tuotu</value>
@@ -493,6 +487,12 @@ Jos olet tarkistanut nämä ja peliäsi ei silti näy, saattaa se olla ohjelmist
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Älä näytä uudelleen</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Lataa</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Ladataan</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Virhe</value>

--- a/src/Translations/fr-FR/Resources.resw
+++ b/src/Translations/fr-FR/Resources.resw
@@ -148,7 +148,7 @@
     <value>Impossible de télécharger la DLL {0}, veuillez réessayer plus tard ou consulter vos logs pour savoir pourquoi le téléchargement a échoué.</value>
     <comment>{0} sera le type de DLL (par ex. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Télécharger</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/fr-FR/Resources.resw
+++ b/src/Translations/fr-FR/Resources.resw
@@ -148,14 +148,8 @@
     <value>Impossible de télécharger la DLL {0}, veuillez réessayer plus tard ou consulter vos logs pour savoir pourquoi le téléchargement a échoué.</value>
     <comment>{0} sera le type de DLL (par ex. DLSS, FSR, XeSS)</comment>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Télécharger</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Erreur de téléchargement</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Téléchargement en cours</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importé</value>
@@ -493,6 +487,12 @@ Si vous avez vérifié ces points et que votre jeu n'apparaît toujours pas, il 
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Ne plus afficher</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Télécharger</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Téléchargement en cours</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Erreur</value>

--- a/src/Translations/fr-FR/Resources.resw
+++ b/src/Translations/fr-FR/Resources.resw
@@ -154,7 +154,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Erreur de téléchargement</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Téléchargement en cours</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/it-IT/Resources.resw
+++ b/src/Translations/it-IT/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Errore nel download</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Download in corso</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/it-IT/Resources.resw
+++ b/src/Translations/it-IT/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Impossibile scaricare {0} DLL. Riprova più tardi o controlla i log per scoprire perché il download non sia riuscito.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Download</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Errore nel download</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Download in corso</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importazione riuscita</value>
@@ -465,6 +459,12 @@ Se hai verificato queste opzioni e il tuo gioco continua a non essere visualizza
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Non mostrare più</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Download</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Download in corso</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Errore</value>

--- a/src/Translations/it-IT/Resources.resw
+++ b/src/Translations/it-IT/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Impossibile scaricare {0} DLL. Riprova più tardi o controlla i log per scoprire perché il download non sia riuscito.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Download</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/ja-JP/Resources.resw
+++ b/src/Translations/ja-JP/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>{0} DLL のダウンロードに失敗しました。後で再試行するか、ログを確認してダウンロードが失敗した原因を確認して下さい。</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>ダウンロード</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/ja-JP/Resources.resw
+++ b/src/Translations/ja-JP/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>ダウンロードエラー</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>ダウンロード中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ja-JP/Resources.resw
+++ b/src/Translations/ja-JP/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>{0} DLL のダウンロードに失敗しました。後で再試行するか、ログを確認してダウンロードが失敗した原因を確認して下さい。</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>ダウンロード</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>ダウンロードエラー</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>ダウンロード中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>インポートされました</value>
@@ -486,6 +480,12 @@ C:\Program Files\MyGamesFolder\MyFavGame\&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>再び表示しない</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>ダウンロード</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>ダウンロード中</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>エラー</value>

--- a/src/Translations/pl-PL/Resources.resw
+++ b/src/Translations/pl-PL/Resources.resw
@@ -141,14 +141,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Nie można pobrać {0} DLL, proszę spróbować później lub lub sprawdzić swoje logi żeby sprawdzić czemu pobieranie się nie powiodło.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Pobierz</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Błąd pobierania</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Pobieranie</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Zaimportowano</value>
@@ -373,6 +367,12 @@ Jeśli sprawdziłeś te ustawienia, a Twoja gra nadal nie jest wyświetlana, mo�
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Nie pokazuj ponownie</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Pobierz</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Pobieranie</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Błąd</value>

--- a/src/Translations/pl-PL/Resources.resw
+++ b/src/Translations/pl-PL/Resources.resw
@@ -141,7 +141,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Nie można pobrać {0} DLL, proszę spróbować później lub lub sprawdzić swoje logi żeby sprawdzić czemu pobieranie się nie powiodło.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Pobierz</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/pl-PL/Resources.resw
+++ b/src/Translations/pl-PL/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Błąd pobierania</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Pobieranie</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/pt-BR/Resources.resw
+++ b/src/Translations/pt-BR/Resources.resw
@@ -69,7 +69,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Não foi possível baixar a DLL do {0}, tente novamente mais tarde ou verifique os logs para entender o motivo da falha.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Baixar</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/pt-BR/Resources.resw
+++ b/src/Translations/pt-BR/Resources.resw
@@ -69,14 +69,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Não foi possível baixar a DLL do {0}, tente novamente mais tarde ou verifique os logs para entender o motivo da falha.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Baixar</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Erro ao baixar</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Baixando</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Importado</value>
@@ -365,6 +359,12 @@ Se você verificou tudo isso e seu jogo ainda não aparece, pode ser um bug. Agr
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Não mostrar novamente</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Baixar</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Baixando</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Erro</value>

--- a/src/Translations/pt-BR/Resources.resw
+++ b/src/Translations/pt-BR/Resources.resw
@@ -75,7 +75,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Erro ao baixar</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Baixando</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ru-RU/Resources.resw
+++ b/src/Translations/ru-RU/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Не удалось загрузить {0} DLL, попробуйте позже или проверьте журналы, чтобы узнать причину сбоя загрузки.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Загрузить</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Ошибка загрузки</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Загрузка</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Импортировано</value>
@@ -482,6 +476,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Не показывать больше</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Загрузить</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Загрузка</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Ошибка</value>

--- a/src/Translations/ru-RU/Resources.resw
+++ b/src/Translations/ru-RU/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Ошибка загрузки</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Загрузка</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/ru-RU/Resources.resw
+++ b/src/Translations/ru-RU/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Не удалось загрузить {0} DLL, попробуйте позже или проверьте журналы, чтобы узнать причину сбоя загрузки.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Загрузить</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/th-TH/Resources.resw
+++ b/src/Translations/th-TH/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>ไม่สามารถดาวน์โหลดไฟล์ DLL {0} ได้โปรดลองใหม่หรือตรวจสอบ Logs เพื่อดูสาเหตุที่ล้มเหลว</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>ดาวน์โหลด</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/th-TH/Resources.resw
+++ b/src/Translations/th-TH/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>ไม่สามารถดาวน์โหลดไฟล์ DLL {0} ได้โปรดลองใหม่หรือตรวจสอบ Logs เพื่อดูสาเหตุที่ล้มเหลว</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>ดาวน์โหลด</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>การดาวน์โหลดผิดพลาด</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>กำลังดาวน์โหลด</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>นำเข้าแล้ว</value>
@@ -482,6 +476,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>ไม่ต้องแสดงอีก</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>ดาวน์โหลด</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>กำลังดาวน์โหลด</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>ข้อผิดพลาด</value>

--- a/src/Translations/th-TH/Resources.resw
+++ b/src/Translations/th-TH/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>การดาวน์โหลดผิดพลาด</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>กำลังดาวน์โหลด</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/tr-TR/Resources.resw
+++ b/src/Translations/tr-TR/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>İndirme Hatası</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>İndiriliyor</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/tr-TR/Resources.resw
+++ b/src/Translations/tr-TR/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>{0} DLL'i indirilemedi. Lütfen daha sonra tekrar deneyin veya indirme işleminin neden başarısız olduğunu görmek için günlüklerinizi  kontrol edin.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>İndir</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>İndirme Hatası</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>İndiriliyor</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>İçe Aktarıldı</value>
@@ -450,6 +444,12 @@ Hangi ön ayarın gerçekten kullanıldığını doğrulamak için, DLSS ekran �
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Tekrar gösterme</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>İndir</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>İndiriliyor</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Hata</value>

--- a/src/Translations/tr-TR/Resources.resw
+++ b/src/Translations/tr-TR/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>{0} DLL'i indirilemedi. Lütfen daha sonra tekrar deneyin veya indirme işleminin neden başarısız olduğunu görmek için günlüklerinizi  kontrol edin.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>İndir</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/uk-UA/Resources.resw
+++ b/src/Translations/uk-UA/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Не вдалося завантажити {0} DLL. Спробуйте пізніше або перегляньте журнали, щоб дізнатися причину.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Завантажити</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Помилка завантаження</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Завантажується</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Імпортовано</value>
@@ -482,6 +476,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Більше не показувати</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Завантажити</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Завантажується</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Помилка</value>

--- a/src/Translations/uk-UA/Resources.resw
+++ b/src/Translations/uk-UA/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Не вдалося завантажити {0} DLL. Спробуйте пізніше або перегляньте журнали, щоб дізнатися причину.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Завантажити</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/uk-UA/Resources.resw
+++ b/src/Translations/uk-UA/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Помилка завантаження</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Завантажується</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/vi-VN/Resources.resw
+++ b/src/Translations/vi-VN/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Không thể tải xuống DLL {0}, vui lòng thử lại sau hoặc kiểm tra nhật ký để xem lý do tải xuống thất bại.</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>Tải xuống</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Lỗi tải xuống</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>Đang tải xuống</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>Đã nhập</value>
@@ -482,6 +476,12 @@ Nếu bạn đã kiểm tra những điều này và trò chơi của bạn vẫ
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>Đừng hiển thị lại</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>Tải xuống</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>Đang tải xuống</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>Lỗi</value>

--- a/src/Translations/vi-VN/Resources.resw
+++ b/src/Translations/vi-VN/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>Lỗi tải xuống</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>Đang tải xuống</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/vi-VN/Resources.resw
+++ b/src/Translations/vi-VN/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>Không thể tải xuống DLL {0}, vui lòng thử lại sau hoặc kiểm tra nhật ký để xem lý do tải xuống thất bại.</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>Tải xuống</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/zh-CN/Resources.resw
+++ b/src/Translations/zh-CN/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>无法下载 {0} DLL 文件，请稍后再试，或查看日志以了解下载失败的原因。</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>下载</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>下载错误</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>下载中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>已导入</value>
@@ -482,6 +476,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>不再提示此信息</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>下载</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>下载中</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>错误</value>

--- a/src/Translations/zh-CN/Resources.resw
+++ b/src/Translations/zh-CN/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>无法下载 {0} DLL 文件，请稍后再试，或查看日志以了解下载失败的原因。</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>下载</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/Translations/zh-CN/Resources.resw
+++ b/src/Translations/zh-CN/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>下载错误</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>下载中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/zh-TW/Resources.resw
+++ b/src/Translations/zh-TW/Resources.resw
@@ -147,14 +147,8 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>無法下載 {0} DLL 檔案，請稍後再試一次或檢查日誌來確認下載錯誤的原因。</value>
   </data>
-  <data name="General_Download" xml:space="preserve">
-    <value>下載</value>
-  </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>下載錯誤</value>
-  </data>
-  <data name="General_Downloading" xml:space="preserve">
-    <value>下載中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">
     <value>已匯入</value>
@@ -455,6 +449,12 @@
   </data>
   <data name="General_DontShowAgain" xml:space="preserve">
     <value>不再顯示</value>
+  </data>
+  <data name="General_Download" xml:space="preserve">
+    <value>下載</value>
+  </data>
+  <data name="General_Downloading" xml:space="preserve">
+    <value>下載中</value>
   </data>
   <data name="General_Error" xml:space="preserve">
     <value>錯誤</value>

--- a/src/Translations/zh-TW/Resources.resw
+++ b/src/Translations/zh-TW/Resources.resw
@@ -153,7 +153,7 @@
   <data name="DllRecord_DownloadError" xml:space="preserve">
     <value>下載錯誤</value>
   </data>
-  <data name="DllRecord_Downloading" xml:space="preserve">
+  <data name="General_Downloading" xml:space="preserve">
     <value>下載中</value>
   </data>
   <data name="DllRecord_Imported" xml:space="preserve">

--- a/src/Translations/zh-TW/Resources.resw
+++ b/src/Translations/zh-TW/Resources.resw
@@ -147,7 +147,7 @@
   <data name="DllRecord_CouldNotDownloadAssetTypeTemplate" xml:space="preserve">
     <value>無法下載 {0} DLL 檔案，請稍後再試一次或檢查日誌來確認下載錯誤的原因。</value>
   </data>
-  <data name="DllRecord_Download" xml:space="preserve">
+  <data name="General_Download" xml:space="preserve">
     <value>下載</value>
   </data>
   <data name="DllRecord_DownloadError" xml:space="preserve">

--- a/src/UserControls/NGXModelImporter.xaml
+++ b/src/UserControls/NGXModelImporter.xaml
@@ -8,9 +8,12 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:tv="using:WinUI.TableView"
     xmlns:nvidia="using:DLSS_Swapper.Data.NVIDIA"
+    xmlns:converters="using:DLSS_Swapper.Converters"
     mc:Ignorable="d">
 
-    
+    <UserControl.Resources>
+        <converters:BytesToMegaBytesConverter x:Key="BytesToMegaBytesConverter" />
+    </UserControl.Resources>
 
     <Grid>
         <tv:TableView x:Name="MainTableView" Grid.Row="0" CornerButtonMode="SelectAll" SelectionMode="None" SelectionUnit="Row" GridLinesVisibility="All" VerticalAlignment="Stretch" AutoGenerateColumns="False" ItemsSource="{x:Bind ViewModel.Models, Mode=OneWay}">
@@ -19,9 +22,13 @@
 
                 <tv:TableViewCheckBoxColumn Binding="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Tag="Checked" IsReadOnly="False" CanSort="False" CanFilter="False" CanReorder="False" CanResize="False" />
 
-                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderAssetTypeText, Mode=OneWay}" Tag="GameAssetType" Binding="{Binding NGXModel.GameAssetTypeString, Mode=OneTime}" IsReadOnly="True" />
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderAssetTypeText, Mode=OneWay}" Tag="GameAssetType" Binding="{Binding NGXModel.GameAssetTypeString, Mode=OneWay}" IsReadOnly="True" />
 
-                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderVersionText, Mode=OneWay}" Tag="Version" Binding="{Binding NGXModel.Version, Mode=OneTime}" IsReadOnly="True" />
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderVersionText, Mode=OneWay}" Tag="Version" Binding="{Binding NGXModel.Version, Mode=OneWay}" IsReadOnly="True" />
+
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderSizeText, Mode=OneWay}" Tag="Size" Binding="{Binding NGXModel.Size, Mode=OneWay, Converter={StaticResource BytesToMegaBytesConverter}}" IsReadOnly="True" />
+
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderStatusText, Mode=OneWay}" Tag="Status" Binding="{Binding StatusMessage, Mode=OneWay}" IsReadOnly="True" />
 
             </tv:TableView.Columns>
 

--- a/src/UserControls/NGXModelImporter.xaml
+++ b/src/UserControls/NGXModelImporter.xaml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DLSS_Swapper.UserControls.NGXModelImporter"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:DLSS_Swapper.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:tv="using:WinUI.TableView"
+    xmlns:nvidia="using:DLSS_Swapper.Data.NVIDIA"
+    mc:Ignorable="d">
+
+    
+
+    <Grid>
+        <tv:TableView x:Name="MainTableView" Grid.Row="0" CornerButtonMode="SelectAll" SelectionMode="None" SelectionUnit="Row" GridLinesVisibility="All" VerticalAlignment="Stretch" AutoGenerateColumns="False" ItemsSource="{x:Bind ViewModel.Models, Mode=OneWay}">
+
+            <tv:TableView.Columns>
+
+                <tv:TableViewCheckBoxColumn Binding="{Binding IsChecked, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" Tag="Checked" IsReadOnly="False" CanSort="False" CanFilter="False" CanReorder="False" CanResize="False" />
+
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderAssetTypeText, Mode=OneWay}" Tag="GameAssetType" Binding="{Binding NGXModel.GameAssetTypeString, Mode=OneTime}" IsReadOnly="True" />
+
+                <tv:TableViewTextColumn Width="*" Header="{x:Bind ViewModel.TranslationProperties.ColumnHeaderVersionText, Mode=OneWay}" Tag="Version" Binding="{Binding NGXModel.Version, Mode=OneTime}" IsReadOnly="True" />
+
+            </tv:TableView.Columns>
+
+            <tv:TableView.ItemTemplate>
+                <DataTemplate x:DataType="nvidia:NGXModelRow">
+                    <tv:TableViewRowPresenter IsEnabled="{x:Bind Path=IsEnabled}" />
+                </DataTemplate>
+            </tv:TableView.ItemTemplate>
+
+        </tv:TableView>
+    </Grid>
+</UserControl>

--- a/src/UserControls/NGXModelImporter.xaml.cs
+++ b/src/UserControls/NGXModelImporter.xaml.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Microsoft.UI.Xaml.Controls;
+using DLSS_Swapper.Data.NVIDIA;
+
+// To learn more about WinUI, the WinUI project structure,
+// and more about our project templates, see: http://aka.ms/winui-project-info.
+
+namespace DLSS_Swapper.UserControls;
+
+public sealed partial class NGXModelImporter : UserControl
+{
+    public NGXModelImporterModel ViewModel { get; private set; }
+
+    public NGXModelImporter(List<NGXModel> models)
+    {
+        InitializeComponent();
+
+        ViewModel = new NGXModelImporterModel(this, models);
+    }
+}

--- a/src/UserControls/NGXModelImporterModel.cs
+++ b/src/UserControls/NGXModelImporterModel.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DLSS_Swapper.Data.NVIDIA;
+
+namespace DLSS_Swapper.UserControls;
+
+public partial class NGXModelImporterModel : ObservableObject
+{
+    WeakReference<NGXModelImporter> _weakControl;
+
+    public List<NGXModelRow> Models { get; }
+
+    public NGXModelImporterModelTranslationProperties TranslationProperties { get; } = new NGXModelImporterModelTranslationProperties();
+
+    public NGXModelImporterModel(NGXModelImporter control, List<NGXModel> models)
+    {
+        _weakControl = new WeakReference<NGXModelImporter>(control);
+
+        Models = new List<NGXModelRow>(models.Count);
+
+        foreach (var model in models.OrderByDescending(a => a.Version).ThenBy(a => a.GameAssetType))
+        {
+            Models.Add(new NGXModelRow(model));
+        }
+    }
+}

--- a/src/UserControls/NGXModelImporterModelTranslationProperties.cs
+++ b/src/UserControls/NGXModelImporterModelTranslationProperties.cs
@@ -11,4 +11,12 @@ public class NGXModelImporterModelTranslationProperties : LocalizedViewModelBase
 
     [TranslationProperty]
     public string ColumnHeaderVersionText => ResourceHelper.GetString("General_Version");
+
+    [TranslationProperty]
+    public string ColumnHeaderSizeText => ResourceHelper.GetString("General_Size");
+
+    [TranslationProperty]
+    public string ColumnHeaderStatusText => ResourceHelper.GetString("General_Status");
+
+    
 }

--- a/src/UserControls/NGXModelImporterModelTranslationProperties.cs
+++ b/src/UserControls/NGXModelImporterModelTranslationProperties.cs
@@ -1,0 +1,14 @@
+using DLSS_Swapper.Attributes;
+using DLSS_Swapper.Helpers;
+using DLSS_Swapper.Interfaces;
+
+namespace DLSS_Swapper.UserControls;
+
+public class NGXModelImporterModelTranslationProperties : LocalizedViewModelBase
+{
+    [TranslationProperty]
+    public string ColumnHeaderAssetTypeText => ResourceHelper.GetString("GameHistoryControl_AssetTypeHeader");
+
+    [TranslationProperty]
+    public string ColumnHeaderVersionText => ResourceHelper.GetString("General_Version");
+}


### PR DESCRIPTION
## Description of Changes

Users can now import DLSS files that are already downloaded by their driver, or directly from NVIDIA server.

This is not an automatic process as first intended, there is a lot of CPU work required to validate the near 1GB of DLLs that the driver has locally.

The feature is activated from the Library page by clicking import > NVIDIA > and then selecting one of the two options available.

<!--
    Describe the changes you made clearly and concisely. If possible, provide details that help to understand the adjustments.
    
    If applicable, include images or screenshots to illustrate the changes made.
-->

## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#865 
<!--
    If you fixed any bugs, list the issues resolved here. Provide one line for each issue that was addressed.
    
    Example:
        #123
        #345
-->
