### PR TITLE
Add "Update All" to swap every game to the latest DLL at once

### DIFF
--- a/src/Data/BulkDllUpdater.cs
+++ b/src/Data/BulkDllUpdater.cs
@@ -1,0 +1,321 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DLSS_Swapper.Helpers;
+
+namespace DLSS_Swapper.Data;
+
+/// <summary>
+/// Provides a "update every game in the library to the latest available DLL" workflow so the user
+/// does not have to open each game one by one and swap a single DLL at a time.
+///
+/// This reuses the exact same per-game swap logic (<see cref="Game.UpdateDllAsync(DLLRecord)"/>) and the
+/// newest-first ordering of the DLL record lists, it just drives them for every game automatically.
+/// </summary>
+internal static class BulkDllUpdater
+{
+    // NOTE: DLL type
+    // The primary (non backup) asset types we are able to swap.
+    static readonly GameAssetType[] SwappableAssetTypes = new[]
+    {
+        GameAssetType.DLSS,
+        GameAssetType.DLSS_G,
+        GameAssetType.DLSS_D,
+        GameAssetType.FSR_31_DX12,
+        GameAssetType.FSR_31_VK,
+        GameAssetType.XeSS,
+        GameAssetType.XeLL,
+        GameAssetType.XeSS_FG,
+        GameAssetType.XeSS_DX11,
+    };
+
+    static IReadOnlyList<DLLRecord> GetRecordsForAssetType(GameAssetType assetType)
+    {
+        // NOTE: DLL type
+        return assetType switch
+        {
+            GameAssetType.DLSS => DLLManager.Instance.DLSSRecords,
+            GameAssetType.DLSS_G => DLLManager.Instance.DLSSGRecords,
+            GameAssetType.DLSS_D => DLLManager.Instance.DLSSDRecords,
+            GameAssetType.FSR_31_DX12 => DLLManager.Instance.FSR31DX12Records,
+            GameAssetType.FSR_31_VK => DLLManager.Instance.FSR31VKRecords,
+            GameAssetType.XeSS => DLLManager.Instance.XeSSRecords,
+            GameAssetType.XeLL => DLLManager.Instance.XeLLRecords,
+            GameAssetType.XeSS_FG => DLLManager.Instance.XeSSFGRecords,
+            GameAssetType.XeSS_DX11 => DLLManager.Instance.XeSSDX11Records,
+            _ => Array.Empty<DLLRecord>(),
+        };
+    }
+
+    /// <summary>
+    /// Returns the newest <see cref="DLLRecord"/> we are allowed to swap a given asset type to, or null if
+    /// there is no applicable record. This mirrors the filtering done by the per-game DLL picker.
+    /// </summary>
+    /// <param name="assetType">The asset type currently installed in the game.</param>
+    /// <param name="currentAssets">The installed asset(s) of that type for the game.</param>
+    /// <param name="allowDownloading">If false, only DLLs already on disk are considered.</param>
+    static DLLRecord? GetLatestApplicableRecord(GameAssetType assetType, IReadOnlyList<GameAsset> currentAssets, bool allowDownloading)
+    {
+        if (currentAssets.Count == 0)
+        {
+            return null;
+        }
+
+        // The record lists are kept sorted newest-first (see DLLRecord.CompareTo), so the first applicable
+        // record in the list is the latest version.
+        var records = GetRecordsForAssetType(assetType).ToList();
+        if (records.Count == 0)
+        {
+            return null;
+        }
+
+        // Don't bulk update to debug/dev DLLs unless the user has explicitly opted in.
+        if (Settings.Instance.AllowDebugDlls == false)
+        {
+            records = records.Where(x => x.IsDevFile == false).ToList();
+        }
+
+        // Mirror the DLL picker behaviour and keep DLSS 1.x games on the 1.x branch and DLSS 2.x+ games on
+        // the 2.x+ branch instead of mixing incompatible major versions.
+        if (assetType == GameAssetType.DLSS)
+        {
+            var isVersionOne = currentAssets[0].Version.StartsWith("1.", StringComparison.Ordinal);
+            records = records.Where(x => x.Version.StartsWith("1.", StringComparison.Ordinal) == isVersionOne).ToList();
+        }
+
+        foreach (var record in records)
+        {
+            if (record.LocalRecord is null)
+            {
+                continue;
+            }
+
+            // If we aren't downloading we can only use DLLs that are already on disk.
+            if (allowDownloading == false && record.LocalRecord.IsDownloaded == false)
+            {
+                continue;
+            }
+
+            return record;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Builds the list of DLL swaps required to bring a single game up to the latest available DLLs.
+    /// Only asset types that the game already has installed (and that have a newer version available) are returned.
+    /// </summary>
+    public static List<GameUpdatePlanItem> GetUpdatePlan(Game game, bool allowDownloading)
+    {
+        var plan = new List<GameUpdatePlanItem>();
+
+        foreach (var assetType in SwappableAssetTypes)
+        {
+            var currentAssets = game.GameAssets.Where(x => x.AssetType == assetType).ToList();
+            if (currentAssets.Count == 0)
+            {
+                continue;
+            }
+
+            var latestRecord = GetLatestApplicableRecord(assetType, currentAssets, allowDownloading);
+            if (latestRecord is null)
+            {
+                continue;
+            }
+
+            // Already up to date if every installed copy is already on the target hash.
+            var allAlreadyOnTarget = currentAssets.All(x => string.Equals(x.Hash, latestRecord.MD5Hash, StringComparison.InvariantCultureIgnoreCase));
+            if (allAlreadyOnTarget)
+            {
+                continue;
+            }
+
+            plan.Add(new GameUpdatePlanItem(assetType, latestRecord));
+        }
+
+        return plan;
+    }
+
+    /// <summary>
+    /// Updates every supplied game to the latest available DLL for each asset type it currently has installed.
+    /// </summary>
+    /// <param name="games">The games to update.</param>
+    /// <param name="allowDownloading">If true, missing DLLs are downloaded as needed; if false only already downloaded DLLs are used.</param>
+    /// <param name="progress">Optional progress reporter.</param>
+    /// <param name="cancellationToken">Token used to stop processing further games.</param>
+    public static async Task<BulkUpdateSummary> UpdateAllAsync(IReadOnlyList<Game> games, bool allowDownloading, IProgress<BulkUpdateProgress>? progress, CancellationToken cancellationToken)
+    {
+        var summary = new BulkUpdateSummary();
+        var totalGames = games.Count;
+        var processedGames = 0;
+
+        void Report(string title, string action)
+        {
+            progress?.Report(new BulkUpdateProgress(processedGames, totalGames, title, action));
+        }
+
+        foreach (var game in games)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                summary.Cancelled = true;
+                break;
+            }
+
+            Report(game.Title, ResourceHelper.GetString("GamesPage_UpdateAll_Status_Checking"));
+
+            List<GameUpdatePlanItem> plan;
+            try
+            {
+                plan = GetUpdatePlan(game, allowDownloading);
+            }
+            catch (Exception err)
+            {
+                Logger.Error(err, $"Failed to build update plan for {game.Title}.");
+                summary.Errors.Add($"{game.Title}: {err.Message}");
+                summary.GamesFailed++;
+                processedGames++;
+                Report(game.Title, string.Empty);
+                continue;
+            }
+
+            if (plan.Count == 0)
+            {
+                summary.GamesAlreadyUpToDate++;
+                processedGames++;
+                Report(game.Title, string.Empty);
+                continue;
+            }
+
+            var gameUpdated = false;
+            var gameFailed = false;
+
+            foreach (var planItem in plan)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    summary.Cancelled = true;
+                    break;
+                }
+
+                var assetTypeName = DLLManager.Instance.GetAssetTypeName(planItem.AssetType);
+                var targetRecord = planItem.TargetRecord;
+
+                // Download the target DLL if we don't already have it on disk.
+                if (targetRecord.LocalRecord?.IsDownloaded == false)
+                {
+                    if (allowDownloading == false)
+                    {
+                        // Shouldn't happen because GetLatestApplicableRecord already filters these out, but be safe.
+                        continue;
+                    }
+
+                    Report(game.Title, ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Status_DownloadingTemplate", assetTypeName, targetRecord.DisplayName));
+
+                    var (downloadSuccess, downloadMessage, downloadCancelled) = await targetRecord.DownloadAsync().ConfigureAwait(false);
+                    if (downloadCancelled)
+                    {
+                        summary.Cancelled = true;
+                        break;
+                    }
+
+                    if (downloadSuccess == false)
+                    {
+                        summary.Errors.Add($"{game.Title} ({assetTypeName}): {downloadMessage}");
+                        gameFailed = true;
+                        continue;
+                    }
+                }
+
+                Report(game.Title, ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Status_SwappingTemplate", assetTypeName, targetRecord.DisplayName));
+
+                var (success, message, promptToRelaunchAsAdmin) = await game.UpdateDllAsync(targetRecord).ConfigureAwait(false);
+                if (success)
+                {
+                    summary.DllsUpdated++;
+                    gameUpdated = true;
+                }
+                else
+                {
+                    summary.Errors.Add($"{game.Title} ({assetTypeName}): {message}");
+                    gameFailed = true;
+                    if (promptToRelaunchAsAdmin)
+                    {
+                        summary.PromptToRelaunchAsAdmin = true;
+                    }
+                }
+            }
+
+            if (gameUpdated)
+            {
+                summary.GamesUpdated++;
+            }
+
+            if (gameFailed)
+            {
+                summary.GamesFailed++;
+            }
+
+            processedGames++;
+            Report(game.Title, string.Empty);
+
+            if (summary.Cancelled)
+            {
+                break;
+            }
+        }
+
+        return summary;
+    }
+}
+
+/// <summary>
+/// A single DLL swap that needs to happen to bring a game up to date.
+/// </summary>
+internal sealed class GameUpdatePlanItem
+{
+    public GameAssetType AssetType { get; }
+    public DLLRecord TargetRecord { get; }
+
+    public GameUpdatePlanItem(GameAssetType assetType, DLLRecord targetRecord)
+    {
+        AssetType = assetType;
+        TargetRecord = targetRecord;
+    }
+}
+
+/// <summary>
+/// Progress snapshot for the bulk update workflow.
+/// </summary>
+internal sealed class BulkUpdateProgress
+{
+    public int ProcessedGames { get; }
+    public int TotalGames { get; }
+    public string CurrentGameTitle { get; }
+    public string CurrentAction { get; }
+
+    public BulkUpdateProgress(int processedGames, int totalGames, string currentGameTitle, string currentAction)
+    {
+        ProcessedGames = processedGames;
+        TotalGames = totalGames;
+        CurrentGameTitle = currentGameTitle;
+        CurrentAction = currentAction;
+    }
+}
+
+/// <summary>
+/// Result of a bulk update run.
+/// </summary>
+internal sealed class BulkUpdateSummary
+{
+    public int GamesUpdated { get; set; }
+    public int DllsUpdated { get; set; }
+    public int GamesAlreadyUpToDate { get; set; }
+    public int GamesFailed { get; set; }
+    public bool PromptToRelaunchAsAdmin { get; set; }
+    public bool Cancelled { get; set; }
+    public List<string> Errors { get; } = new List<string>();
+}

--- a/src/Pages/GameGridPage.xaml
+++ b/src/Pages/GameGridPage.xaml
@@ -241,6 +241,11 @@
                         <FontIcon Glyph="&#xE72C;" />
                     </AppBarButton.Content>
                 </AppBarButton>
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.UpdateAllText, Mode=OneWay}" Command="{x:Bind ViewModel.UpdateAllGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.IsLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
+                    <AppBarButton.Content>
+                        <FontIcon Glyph="&#xE777;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
                 <AppBarButton Icon="Filter" Label="{x:Bind ViewModel.TranslationProperties.FilterText, Mode=OneWay}" Command="{x:Bind ViewModel.FilterGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.IsGameListLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xE71C;" />

--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -289,6 +291,199 @@ public partial class GameGridPageModel : ObservableObject
         await GameManager.Instance.LoadGamesAsync(true);
 
         IsDLSSLoading = false;
+    }
+
+    [RelayCommand]
+    async Task UpdateAllGamesButtonAsync()
+    {
+        var games = GameManager.Instance.GetSynchronisedGamesListCopy();
+        if (games.Count == 0)
+        {
+            var noGamesDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("GamesPage_UpdateAll_Title"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                Content = ResourceHelper.GetString("GamesPage_UpdateAll_NoGames"),
+            };
+            await noGamesDialog.ShowAsync();
+            return;
+        }
+
+        // Confirmation, with the option to download any missing DLLs as part of the update.
+        var downloadCheckbox = new CheckBox()
+        {
+            Content = new TextBlock()
+            {
+                Text = ResourceHelper.GetString("GamesPage_UpdateAll_DownloadIfNeeded"),
+                TextWrapping = TextWrapping.Wrap,
+            },
+            IsChecked = true,
+        };
+
+        var confirmDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_UpdateAll_Title"),
+            PrimaryButtonText = ResourceHelper.GetString("GamesPage_UpdateAll_Confirm"),
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            DefaultButton = ContentDialogButton.Primary,
+            Content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 16,
+                Children =
+                {
+                    new TextBlock()
+                    {
+                        TextWrapping = TextWrapping.Wrap,
+                        Text = ResourceHelper.GetString("GamesPage_UpdateAll_Message"),
+                    },
+                    downloadCheckbox,
+                },
+            },
+        };
+
+        var confirmResult = await confirmDialog.ShowAsync();
+        if (confirmResult != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        var allowDownloading = downloadCheckbox.IsChecked == true;
+
+        // Progress UI. The Close button doubles as a Cancel button while the update is running.
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var progressBar = new ProgressBar()
+        {
+            Minimum = 0,
+            Maximum = games.Count,
+            Value = 0,
+        };
+        var statusTextBlock = new TextBlock()
+        {
+            TextWrapping = TextWrapping.Wrap,
+        };
+        var detailTextBlock = new TextBlock()
+        {
+            TextWrapping = TextWrapping.Wrap,
+            Opacity = 0.7,
+        };
+
+        var progressDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_UpdateAll_Updating"),
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            Content = new StackPanel()
+            {
+                Orientation = Orientation.Vertical,
+                Spacing = 12,
+                Children = { progressBar, statusTextBlock, detailTextBlock },
+            },
+        };
+        progressDialog.CloseButtonClick += (sender, args) =>
+        {
+            // Don't let the dialog close instantly, let the in-flight game finish and the work loop exit cleanly.
+            args.Cancel = true;
+            cancellationTokenSource.Cancel();
+            statusTextBlock.Text = ResourceHelper.GetString("GamesPage_UpdateAll_Status_Cancelling");
+        };
+
+        // Progress<T> captures the current (UI) SynchronizationContext so these callbacks are safe to touch UI.
+        var progress = new Progress<BulkUpdateProgress>(update =>
+        {
+            progressBar.Maximum = update.TotalGames;
+            progressBar.Value = update.ProcessedGames;
+            statusTextBlock.Text = ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Status_ProgressTemplate", update.ProcessedGames, update.TotalGames, update.CurrentGameTitle);
+            detailTextBlock.Text = update.CurrentAction;
+        });
+
+        var workTask = Task.Run(() => BulkDllUpdater.UpdateAllAsync(games, allowDownloading, progress, cancellationTokenSource.Token));
+
+        // Start showing the progress dialog, wait for the work to finish, then close it. Hiding after the work
+        // completes (rather than auto-hiding from a continuation) avoids a race when the work finishes instantly.
+        var showDialogTask = progressDialog.ShowAsync().AsTask();
+        var summary = await workTask;
+        progressDialog.Hide();
+        await showDialogTask;
+
+        await ShowBulkUpdateSummaryAsync(summary);
+    }
+
+    async Task ShowBulkUpdateSummaryAsync(BulkUpdateSummary summary)
+    {
+        var messageLines = new List<string>()
+        {
+            ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Summary_GamesUpdatedTemplate", summary.GamesUpdated),
+            ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Summary_DllsUpdatedTemplate", summary.DllsUpdated),
+            ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Summary_AlreadyUpToDateTemplate", summary.GamesAlreadyUpToDate),
+        };
+
+        if (summary.GamesFailed > 0)
+        {
+            messageLines.Add(ResourceHelper.GetFormattedResourceTemplate("GamesPage_UpdateAll_Summary_FailedTemplate", summary.GamesFailed));
+        }
+
+        if (summary.Cancelled)
+        {
+            messageLines.Add(ResourceHelper.GetString("GamesPage_UpdateAll_Summary_Cancelled"));
+        }
+
+        var content = new StackPanel()
+        {
+            Orientation = Orientation.Vertical,
+            Spacing = 12,
+            Children =
+            {
+                new TextBlock()
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    Text = string.Join("\n", messageLines),
+                },
+            },
+        };
+
+        // Show details of any failures so the user knows what went wrong.
+        if (summary.Errors.Count > 0)
+        {
+            content.Children.Add(new TextBlock()
+            {
+                TextWrapping = TextWrapping.Wrap,
+                FontWeight = Microsoft.UI.Text.FontWeights.SemiBold,
+                Text = ResourceHelper.GetString("GamesPage_UpdateAll_Summary_Errors"),
+            });
+
+            content.Children.Add(new ScrollViewer()
+            {
+                MaxHeight = 200,
+                Content = new TextBlock()
+                {
+                    TextWrapping = TextWrapping.Wrap,
+                    Opacity = 0.8,
+                    Text = string.Join("\n", summary.Errors),
+                },
+            });
+        }
+
+        var summaryDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_UpdateAll_Summary_Title"),
+            CloseButtonText = ResourceHelper.GetString("General_Okay"),
+            DefaultButton = ContentDialogButton.Close,
+            Content = content,
+        };
+
+        // Offer to relaunch as admin if a write was blocked by permissions.
+        if (summary.PromptToRelaunchAsAdmin && App.CurrentApp.IsAdminUser() == false)
+        {
+            summaryDialog.PrimaryButtonText = ResourceHelper.GetString("General_RestartAsAdministrator");
+            summaryDialog.DefaultButton = ContentDialogButton.Primary;
+        }
+
+        var result = await summaryDialog.ShowAsync();
+        if (result == ContentDialogResult.Primary && summary.PromptToRelaunchAsAdmin)
+        {
+            App.CurrentApp.RestartAsAdmin();
+        }
     }
 
     [RelayCommand]

--- a/src/Pages/GameGridPageModelTranslationProperties.cs
+++ b/src/Pages/GameGridPageModelTranslationProperties.cs
@@ -16,6 +16,9 @@ public class GameGridPageModelTranslationProperties : LocalizedViewModelBase
     public string RefreshText => ResourceHelper.GetString("General_Refresh");
 
     [TranslationProperty]
+    public string UpdateAllText => ResourceHelper.GetString("GamesPage_UpdateAll");
+
+    [TranslationProperty]
     public string FilterText => ResourceHelper.GetString("General_Filter");
 
     [TranslationProperty]

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -458,6 +458,70 @@ If you have checked these and your game is still not showing up there may be a b
   <data name="GamesPage_Title" xml:space="preserve">
     <value>Games</value>
   </data>
+  <data name="GamesPage_UpdateAll" xml:space="preserve">
+    <value>Update All</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Title" xml:space="preserve">
+    <value>Update all games</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Message" xml:space="preserve">
+    <value>This will update every game in your library to the latest available version of each DLL it currently uses (DLSS, FSR, XeSS, etc.). A backup of each original DLL is kept so you can reset later.</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Confirm" xml:space="preserve">
+    <value>Update all</value>
+  </data>
+  <data name="GamesPage_UpdateAll_DownloadIfNeeded" xml:space="preserve">
+    <value>Download the latest DLLs if they are not already downloaded</value>
+  </data>
+  <data name="GamesPage_UpdateAll_NoGames" xml:space="preserve">
+    <value>There are no games to update.</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Updating" xml:space="preserve">
+    <value>Updating games</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Status_Checking" xml:space="preserve">
+    <value>Checking for updates…</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Status_Cancelling" xml:space="preserve">
+    <value>Cancelling…</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Status_ProgressTemplate" xml:space="preserve">
+    <comment>{0} = processed game count, {1} = total game count, {2} = current game title</comment>
+    <value>{0} of {1} — {2}</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Status_DownloadingTemplate" xml:space="preserve">
+    <comment>{0} = DLL type name, {1} = DLL version</comment>
+    <value>Downloading {0} {1}…</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Status_SwappingTemplate" xml:space="preserve">
+    <comment>{0} = DLL type name, {1} = DLL version</comment>
+    <value>Swapping {0} {1}…</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_Title" xml:space="preserve">
+    <value>Update complete</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_GamesUpdatedTemplate" xml:space="preserve">
+    <comment>{0} = number of games updated</comment>
+    <value>Games updated: {0}</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_DllsUpdatedTemplate" xml:space="preserve">
+    <comment>{0} = number of DLLs swapped</comment>
+    <value>DLLs swapped: {0}</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_AlreadyUpToDateTemplate" xml:space="preserve">
+    <comment>{0} = number of games already up to date</comment>
+    <value>Already up to date: {0}</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_FailedTemplate" xml:space="preserve">
+    <comment>{0} = number of games with errors</comment>
+    <value>Games with errors: {0}</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_Cancelled" xml:space="preserve">
+    <value>The update was cancelled before all games were processed.</value>
+  </data>
+  <data name="GamesPage_UpdateAll_Summary_Errors" xml:space="preserve">
+    <value>Details:</value>
+  </data>
   <data name="GamesPage_ViewType" xml:space="preserve">
     <value>View Type</value>
   </data>
@@ -626,6 +690,9 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="General_ReportIssue" xml:space="preserve">
     <value>Report issue</value>
+  </data>
+  <data name="General_RestartAsAdministrator" xml:space="preserve">
+    <value>Restart as administrator</value>
   </data>
   <data name="General_Save" xml:space="preserve">
     <value>Save</value>


### PR DESCRIPTION
## Summary

Adds a bulk update workflow so users no longer have to open each game and swap a single DLL at a time. A new **Update All** button on the games page updates every game in the library to the latest available version of each DLL it already uses.

## What it does

- New `BulkDllUpdater` engine that, for every game, finds the latest available DLL for each asset type the game already uses (DLSS, DLSS-G, DLSS-D, FSR 3.1 DX12/VK, XeSS, XeLL, XeSS-FG, XeSS-DX11) and swaps it, optionally downloading missing DLLs first.
- Reuses the existing `Game.UpdateDllAsync` so original DLLs are still backed up and can be reset.
- Mirrors the per-game picker rules: skips dev/debug DLLs unless enabled, keeps DLSS 1.x games on the 1.x branch, and skips games already up to date.
- New **Update All** toolbar button with confirmation (incl. an "also download missing DLLs" option), live cancellable progress, and a summary dialog — including an offer to restart as administrator when a swap is blocked by permissions.
- en-US strings for all new UI (other languages fall back to en-US).

## Notes

- No changes to existing swap/reset behaviour; this only drives it in bulk.
- Builds clean with `dotnet build` (0 errors) against .NET 10 / WindowsAppSDK 1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)