### PR TITLE
Change how we detect if a game is an addon or not

### DIFF
--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -113,7 +113,7 @@ internal class EpicGamesStoreLibrary : IGameLibrary
                 }
 
                 // Check that is is the base game
-                if (manifest.AppName != manifest.MainGameAppName)
+                if (string.IsNullOrWhiteSpace(manifest.MainGameAppName) == false)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Description of Changes

We were previously checking if a game as a game or DLC by checking if he `AppName` was not hte same as `MainGameAppName`.  

```csharp
if (manifest.AppName != manifest.MainGameAppName)
```

At some point this broke. I am unable to replicate an instance where we wouldn't have a base game. Instead I changed this to check `MainGameAppName` is empty.

```csharp
if (string.IsNullOrWhiteSpace(manifest.MainGameAppName) == false)
```

In theory if a game has a `MainGameAppName` it is a DLC addon. However because I can't find any DLC addons I am unable to verify if this fixes the issue. At minimum it restores EGS to work even if it shows too many games instead of not enough.


## Type of Change

<!--
    Uncomment the line below that corresponds to the type of change made in the PR.

    Mark the appropriate option with an 'x'.
-->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#894