### PR TITLE
Add batch DLL swap: select multiple games and apply in one pass

### DIFF
--- a/src/Data/BatchSwapResult.cs
+++ b/src/Data/BatchSwapResult.cs
@@ -1,0 +1,38 @@
+using DLSS_Swapper.Helpers;
+
+namespace DLSS_Swapper.Data;
+
+public enum BatchSwapStatus
+{
+    Swapped,
+    Skipped,
+    Error,
+}
+
+public class BatchSwapResult
+{
+    public string GameTitle { get; init; } = string.Empty;
+    public BatchSwapStatus Status { get; init; }
+
+    // Localised, game-agnostic action label built on the UI thread before the
+    // worker starts (e.g. "DLSS → 3.7.0" or "Preset DLSS → D"). Never resolved
+    // inside the batch worker.
+    public string ActionLabel { get; init; } = string.Empty;
+
+    // Resource key explaining a skip. Resolved lazily so it is read on the UI
+    // thread at display time, not inside the batch worker.
+    public string ReasonKey { get; init; } = string.Empty;
+
+    // Raw (unlocalised) message from Game.UpdateDllAsync when Status is Error.
+    public string ErrorMessage { get; init; } = string.Empty;
+
+    public bool PromptToRelaunchAsAdmin { get; init; }
+
+    public string DisplayText => Status switch
+    {
+        BatchSwapStatus.Skipped => $"{GameTitle} — {ActionLabel} — {ResourceHelper.GetString(ReasonKey)}",
+        BatchSwapStatus.Error when string.IsNullOrEmpty(ErrorMessage) => $"{GameTitle} — {ActionLabel} — {ResourceHelper.GetString("GamesPage_Batch_Error_Generic")}",
+        BatchSwapStatus.Error => $"{GameTitle} — {ActionLabel} — {ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_Error_PossiblyPartialTemplate", ErrorMessage)}",
+        _ => $"{GameTitle} — {ActionLabel}",
+    };
+}

--- a/src/Data/DLLManager.cs
+++ b/src/Data/DLLManager.cs
@@ -787,6 +787,40 @@ internal class DLLManager
         };
     }
 
+    /// <summary>
+    /// Decides if a batch swap can apply dllRecord to game. ReasonKey is a resource
+    /// key describing why not. Mirrors the DLSS 1.x vs 2/3 rule from
+    /// DLLPickerControlModel, but evaluates every DLSS asset instead of only the
+    /// first: UpdateDllAsync overwrites every matching asset with the same dll, so
+    /// games mixing generations must be skipped.
+    /// </summary>
+    internal static (bool Compatible, string ReasonKey) GetBatchCompatibility(Game game, DLLRecord dllRecord)
+    {
+        var existingAssets = game.GameAssets.Where(x => x.AssetType == dllRecord.AssetType).ToList();
+        if (existingAssets.Count == 0)
+        {
+            return (false, "GamesPage_Batch_Skipped_NoAsset");
+        }
+
+        if (dllRecord.AssetType == GameAssetType.DLSS)
+        {
+            var hasV1Assets = existingAssets.Any(x => x.Version.StartsWith("1."));
+            var hasV2PlusAssets = existingAssets.Any(x => x.Version.StartsWith("1.") == false);
+
+            if (hasV1Assets == true && hasV2PlusAssets == true)
+            {
+                return (false, "GamesPage_Batch_Skipped_MixedGenerations");
+            }
+
+            var recordIsV1 = dllRecord.Version.StartsWith("1.");
+            if (hasV1Assets != recordIsV1)
+            {
+                return (false, "GamesPage_Batch_Skipped_Incompatible");
+            }
+        }
+
+        return (true, string.Empty);
+    }
 
     public GameAssetType GetAssetBackupType(GameAssetType assetType)
     {

--- a/src/Data/DLLRecord.cs
+++ b/src/Data/DLLRecord.cs
@@ -283,6 +283,11 @@ public class DLLRecord : IComparable<DLLRecord>, INotifyPropertyChanged
         try
         {
             LocalRecord.FileDownloader = fileDownloader;
+            // Reset stale error state from a previous failed attempt, otherwise a
+            // cancelled retry is misreported as an error by observers that
+            // distinguish cancel from error via HasDownloadError.
+            LocalRecord.HasDownloadError = false;
+            LocalRecord.DownloadErrorMessage = string.Empty;
             NotifyPropertyChanged(nameof(LocalRecord));
 
 

--- a/src/Pages/GameGridPage.xaml
+++ b/src/Pages/GameGridPage.xaml
@@ -97,6 +97,20 @@
 
             <GridView PointerWheelChanged="MainGridView_PointerWheelChanged" ManipulationMode="None" x:Name="MainGridView" ItemsSource="{x:Bind CurrentCollectionView, Mode=OneWay}" SelectionMode="None" IsItemClickEnabled="True" ItemClick="GridAndListView_ItemClick" Padding="20"  >
 
+                <GridView.Resources>
+                    <!-- White selection checkmark backdrop for contrast against varied cover art (default uses the accent color). -->
+                    <SolidColorBrush x:Key="GridViewItemCheckBoxSelectedBrush" Color="White" />
+                    <SolidColorBrush x:Key="GridViewItemCheckBoxSelectedPointerOverBrush" Color="White" />
+                    <SolidColorBrush x:Key="GridViewItemCheckBoxSelectedPressedBrush" Color="#DDDDDD" />
+                    <SolidColorBrush x:Key="GridViewItemCheckBrush" Color="Black" />
+
+                    <!-- The item container draws behind the cover art, so its selected background only
+                         shows through the padding added below, reading as an accent frame. -->
+                    <StaticResource x:Key="GridViewItemBackgroundSelected" ResourceKey="AccentFillColorDefaultBrush" />
+                    <StaticResource x:Key="GridViewItemBackgroundSelectedPointerOver" ResourceKey="AccentFillColorSecondaryBrush" />
+                    <StaticResource x:Key="GridViewItemBackgroundSelectedPressed" ResourceKey="AccentFillColorTertiaryBrush" />
+                </GridView.Resources>
+
                 <GridView.GroupStyle>
                     <GroupStyle HidesIfEmpty="True">
                         <GroupStyle.HeaderTemplate>
@@ -115,6 +129,10 @@
                         <Setter Property="VerticalContentAlignment" Value="Stretch"/>
                         <Setter Property="Margin" Value="8"/>
                         <Setter Property="BorderThickness" Value="0"/>
+                        <!-- Padding + matching corner radius are what make the selected background
+                             visible as a frame around the 8px-rounded card content. -->
+                        <Setter Property="Padding" Value="3"/>
+                        <Setter Property="CornerRadius" Value="11"/>
                     </Style>
                 </GridView.ItemContainerStyle>
 
@@ -231,22 +249,27 @@
                         <FontIcon Glyph="&#xE946;" />
                     </AppBarButton.Content>
                 </AppBarButton>
-                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.AddGameText, Mode=OneWay}" Command="{x:Bind ViewModel.AddManualGameButtonCommand}" IsEnabled="{x:Bind ViewModel.IsGameListLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.AddGameText, Mode=OneWay}" Command="{x:Bind ViewModel.AddManualGameButtonCommand}" IsEnabled="{x:Bind ViewModel.CanUseFilterAndView, Mode=OneWay}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xE710;" />
                     </AppBarButton.Content>
                 </AppBarButton>
-                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.RefreshText, Mode=OneWay}" Command="{x:Bind ViewModel.RefreshGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.IsLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.RefreshText, Mode=OneWay}" Command="{x:Bind ViewModel.RefreshGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.CanRefresh, Mode=OneWay}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xE72C;" />
                     </AppBarButton.Content>
                 </AppBarButton>
-                <AppBarButton Icon="Filter" Label="{x:Bind ViewModel.TranslationProperties.FilterText, Mode=OneWay}" Command="{x:Bind ViewModel.FilterGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.IsGameListLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.SelectText, Mode=OneWay}" Command="{x:Bind ViewModel.ToggleSelectionModeCommand}" IsEnabled="{x:Bind ViewModel.IsGameListLoading, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}">
+                    <AppBarButton.Content>
+                        <FontIcon Glyph="&#xE762;" />
+                    </AppBarButton.Content>
+                </AppBarButton>
+                <AppBarButton Icon="Filter" Label="{x:Bind ViewModel.TranslationProperties.FilterText, Mode=OneWay}" Command="{x:Bind ViewModel.FilterGamesButtonCommand}" IsEnabled="{x:Bind ViewModel.CanUseFilterAndView, Mode=OneWay}">
                     <AppBarButton.Content>
                         <FontIcon Glyph="&#xE71C;" />
                     </AppBarButton.Content>
                 </AppBarButton>
-                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.ViewTypeText, Mode=OneWay}" Content="{x:Bind ViewModel.GameGridViewIcon, Mode=OneWay}">
+                <AppBarButton Label="{x:Bind ViewModel.TranslationProperties.ViewTypeText, Mode=OneWay}" Content="{x:Bind ViewModel.GameGridViewIcon, Mode=OneWay}" IsEnabled="{x:Bind ViewModel.CanUseFilterAndView, Mode=OneWay}">
                     <AppBarButton.Flyout>
                         <MenuFlyout>
                             <MenuFlyoutItem Text="{x:Bind ViewModel.TranslationProperties.GridViewText, Mode=OneWay}" Command="{x:Bind ViewModel.ChangeGameGridViewCommand}" CommandParameter="{x:Bind pages:GameGridViewType.GridView}" />
@@ -267,6 +290,25 @@
         </Grid>
 
         <ContentControl x:Name="MainContentControl" Grid.Row="1" HorizontalAlignment="Stretch" HorizontalContentAlignment="Stretch" VerticalAlignment="Stretch" Content="{x:Bind ViewModel, Mode=OneWay}" ContentTemplateSelector="{StaticResource TemplateSelector}" />
-        
+
+        <Border Grid.Row="1"
+                VerticalAlignment="Bottom"
+                HorizontalAlignment="Center"
+                Margin="0,0,0,24"
+                Padding="16,8"
+                CornerRadius="8"
+                BorderThickness="1"
+                Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                Visibility="{x:Bind ViewModel.IsSelectionMode, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+            <StackPanel Orientation="Horizontal" Spacing="12">
+                <TextBlock Text="{x:Bind ViewModel.SelectedGamesCountText, Mode=OneWay}" VerticalAlignment="Center" />
+                <Button Content="{x:Bind ViewModel.SelectAllButtonText, Mode=OneWay}" Command="{x:Bind ViewModel.ToggleSelectAllCommand}" />
+                <Button Style="{StaticResource AccentButtonStyle}" Content="{x:Bind ViewModel.TranslationProperties.ApplyDllText, Mode=OneWay}" Command="{x:Bind ViewModel.ApplyBatchDllCommand}" />
+                <Button Content="{x:Bind ViewModel.TranslationProperties.ClearText, Mode=OneWay}" Command="{x:Bind ViewModel.ClearSelectionCommand}" />
+                <Button Content="{x:Bind ViewModel.TranslationProperties.DoneText, Mode=OneWay}" Command="{x:Bind ViewModel.ToggleSelectionModeCommand}" />
+            </StackPanel>
+        </Border>
+
     </Grid>
 </Page>

--- a/src/Pages/GameGridPage.xaml.cs
+++ b/src/Pages/GameGridPage.xaml.cs
@@ -192,4 +192,143 @@ public sealed partial class GameGridPage : Page
     {
         SearchBox.Text = string.Empty;
     }
+
+    bool _isSyncingSelection;
+
+    ListViewBase? GetActiveListControl()
+    {
+        return MainContentControl.ContentTemplateRoot as ListViewBase;
+    }
+
+    internal void EnterSelectionMode()
+    {
+        var listControl = GetActiveListControl();
+        if (listControl is null)
+        {
+            return;
+        }
+
+        listControl.SelectionMode = ListViewSelectionMode.Multiple;
+        listControl.IsItemClickEnabled = false;
+        listControl.SelectionChanged += ListControl_SelectionChanged;
+    }
+
+    internal void ExitSelectionMode()
+    {
+        var listControl = GetActiveListControl();
+        if (listControl is null)
+        {
+            return;
+        }
+
+        listControl.SelectionChanged -= ListControl_SelectionChanged;
+        _isSyncingSelection = true;
+        try
+        {
+            listControl.SelectedItems.Clear();
+        }
+        finally
+        {
+            _isSyncingSelection = false;
+        }
+        listControl.SelectionMode = ListViewSelectionMode.None;
+        listControl.IsItemClickEnabled = true;
+    }
+
+    // Number of items the active list is currently showing, which is what
+    // "select all" acts on -- the current filter and search already applied.
+    internal int GetVisibleItemCount()
+    {
+        return GetActiveListControl()?.Items.Count ?? 0;
+    }
+
+    // Number of currently visible items that are also selected. SelectedGames can
+    // contain games hidden by the current search filter, so SelectedGames.Count
+    // alone says nothing about the visible items.
+    internal int GetVisibleSelectedCount()
+    {
+        var listControl = GetActiveListControl();
+        if (listControl is null)
+        {
+            return 0;
+        }
+
+        var count = 0;
+        foreach (var game in ViewModel.SelectedGames)
+        {
+            if (listControl.Items.Contains(game))
+            {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    internal void SelectAllVisible()
+    {
+        // SelectAll raises SelectionChanged, so the view model picks the games up
+        // through the usual UpdateSelection path.
+        GetActiveListControl()?.SelectAll();
+    }
+
+    void ListControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_isSyncingSelection == true)
+        {
+            return;
+        }
+
+        ViewModel.UpdateSelection(e.AddedItems, e.RemovedItems);
+    }
+
+    internal void BeginSuppressSelectionEvents()
+    {
+        _isSyncingSelection = true;
+    }
+
+    // Called after CurrentCollectionView changes while selection mode is active.
+    // The binding applies the new ItemsSource asynchronously, so the visual
+    // selection is re-applied at low priority, after the list picked it up.
+    internal void ResyncVisualSelectionAfterViewChange()
+    {
+        var enqueued = DispatcherQueue.TryEnqueue(Microsoft.UI.Dispatching.DispatcherQueuePriority.Low, () =>
+        {
+            ResyncVisualSelection();
+        });
+
+        // BeginSuppressSelectionEvents set _isSyncingSelection before the ItemsSource
+        // swap; if the resync could not be queued, nothing else would ever reset it
+        // and all selection events would be ignored from here on.
+        if (enqueued == false)
+        {
+            _isSyncingSelection = false;
+        }
+    }
+
+    internal void ResyncVisualSelection()
+    {
+        var listControl = GetActiveListControl();
+        if (listControl is null)
+        {
+            _isSyncingSelection = false;
+            return;
+        }
+
+        _isSyncingSelection = true;
+        try
+        {
+            listControl.SelectedItems.Clear();
+            foreach (var game in ViewModel.SelectedGames)
+            {
+                if (listControl.Items.Contains(game))
+                {
+                    listControl.SelectedItems.Add(game);
+                }
+            }
+        }
+        finally
+        {
+            _isSyncingSelection = false;
+        }
+    }
 }

--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
@@ -31,10 +34,13 @@ public partial class GameGridPageModel : ObservableObject
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsLoading))]
+    [NotifyPropertyChangedFor(nameof(CanUseFilterAndView))]
+    [NotifyPropertyChangedFor(nameof(CanRefresh))]
     public partial bool IsGameListLoading { get; set; } = true;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsLoading))]
+    [NotifyPropertyChangedFor(nameof(CanRefresh))]
     public partial bool IsDLSSLoading { get; set; } = true;
 
     public bool IsLoading => (IsGameListLoading || IsDLSSLoading);
@@ -61,6 +67,554 @@ public partial class GameGridPageModel : ObservableObject
     };
 
     public GameGridPageModelTranslationProperties TranslationProperties { get; } = new GameGridPageModelTranslationProperties();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanUseFilterAndView))]
+    [NotifyPropertyChangedFor(nameof(CanRefresh))]
+    public partial bool IsSelectionMode { get; set; } = false;
+
+    public List<Game> SelectedGames { get; } = new List<Game>();
+
+    public string SelectedGamesCountText => ResourceHelper.GetFormattedResourceTemplate("GamesPage_SelectionMode_CountTemplate", SelectedGames.Count);
+
+    public bool CanApplyBatchDll => SelectedGames.Count > 0;
+
+    bool AreAllVisibleGamesSelected
+    {
+        get
+        {
+            var visibleCount = gameGridPage.GetVisibleItemCount();
+            return visibleCount > 0 && gameGridPage.GetVisibleSelectedCount() == visibleCount;
+        }
+    }
+
+    public string SelectAllButtonText => AreAllVisibleGamesSelected
+        ? ResourceHelper.GetString("GamesPage_SelectionMode_DeselectAll")
+        : ResourceHelper.GetString("GamesPage_SelectionMode_SelectAll");
+
+    public bool CanUseFilterAndView => IsGameListLoading == false && IsSelectionMode == false;
+
+    public bool CanRefresh => IsLoading == false && IsSelectionMode == false;
+
+    [RelayCommand]
+    void ToggleSelectionMode()
+    {
+        if (IsSelectionMode == false)
+        {
+            IsSelectionMode = true;
+            gameGridPage.EnterSelectionMode();
+        }
+        else
+        {
+            IsSelectionMode = false;
+            gameGridPage.ExitSelectionMode();
+            SelectedGames.Clear();
+            NotifySelectionChanged();
+        }
+    }
+
+    [RelayCommand]
+    void ToggleSelectAll()
+    {
+        if (AreAllVisibleGamesSelected == true)
+        {
+            SelectedGames.Clear();
+            gameGridPage.ResyncVisualSelection();
+        }
+        else
+        {
+            gameGridPage.SelectAllVisible();
+        }
+
+        NotifySelectionChanged();
+    }
+
+    [RelayCommand]
+    void ClearSelection()
+    {
+        SelectedGames.Clear();
+        gameGridPage.ResyncVisualSelection();
+        NotifySelectionChanged();
+    }
+
+    [RelayCommand(CanExecute = nameof(CanApplyBatchDll))]
+    async Task ApplyBatchDllAsync()
+    {
+        // 1. Configure the actions to apply (DLL and/or preset per type).
+        var pickerDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_Batch_Title"),
+            PrimaryButtonText = ResourceHelper.GetString("General_Apply"),
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            DefaultButton = ContentDialogButton.Primary,
+        };
+        // The default ContentDialogMaxWidth (548) clips the picker's version and
+        // preset columns, which truncates longer localised type names.
+        pickerDialog.Resources["ContentDialogMaxWidth"] = 680d;
+        var picker = new BatchDllPickerControl(pickerDialog);
+        pickerDialog.Content = picker;
+
+        var pickerResult = await pickerDialog.ShowAsync();
+        if (pickerResult != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        // Collect actions and pre-compose their localised, game-agnostic labels on
+        // the UI thread so the worker never touches ResourceHelper.
+        var dllActions = picker.ViewModel.PlannedDllActions
+            .Select(a => new BatchDllActionItem(
+                a.Type,
+                a.Record,
+                ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_DllLabelTemplate", DLLManager.Instance.GetAssetTypeName(a.Type), a.Record.DisplayName)))
+            .ToList();
+
+        var presetActions = picker.ViewModel.PlannedPresetActions
+            .Select(a => new BatchPresetActionItem(
+                a.Type,
+                a.Preset.Value,
+                ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_PresetLabelTemplate", DLLManager.Instance.GetAssetTypeName(a.Type), a.Preset.Name)))
+            .ToList();
+
+        if (dllActions.Count == 0 && presetActions.Count == 0)
+        {
+            return;
+        }
+
+        // 2. Make sure every chosen DLL is on disk before touching any game.
+        foreach (var action in dllActions)
+        {
+            // The picker only plans records with a LocalRecord, but re-validate
+            // rather than trust it: a null LocalRecord would NRE below.
+            if (action.Record.LocalRecord is null)
+            {
+                var localRecordErrorDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+                {
+                    Title = ResourceHelper.GetString("General_Error"),
+                    CloseButtonText = ResourceHelper.GetString("General_Close"),
+                    DefaultButton = ContentDialogButton.Close,
+                    Content = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_DownloadFailedTemplate", action.Record.DisplayName),
+                };
+                await localRecordErrorDialog.ShowAsync();
+                return;
+            }
+
+            if (action.Record.LocalRecord.IsDownloaded != true)
+            {
+                var downloaded = await EnsureDownloadedAsync(action.Record);
+                if (downloaded == false)
+                {
+                    return;
+                }
+            }
+        }
+
+        // 3. Progress dialog (determinate, one tick per game).
+        var gamesToProcess = SelectedGames.ToList();
+
+        var progressBar = new ProgressBar()
+        {
+            Minimum = 0,
+            Maximum = gamesToProcess.Count,
+            Value = 0,
+            IsIndeterminate = false,
+        };
+        var progressTextBlock = new TextBlock();
+        var progressStackPanel = new StackPanel()
+        {
+            Spacing = 16,
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                progressBar,
+                progressTextBlock,
+            },
+        };
+        var progressDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_Batch_Title"),
+            Content = progressStackPanel,
+        };
+        _ = progressDialog.ShowAsync();
+
+        // Give UI time to show the dialog (same as ExportAllAsync).
+        await Task.Delay(50);
+
+        var results = new List<BatchSwapResult>();
+        var progress = new Progress<int>(current =>
+        {
+            progressBar.Value = current;
+            progressTextBlock.Text = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_ApplyingTemplate", current, gamesToProcess.Count);
+        });
+
+        // Once an NVAPI permission failure flips IsSupported to false, every later
+        // preset call fails immediately. Track it so we report the rest as skipped
+        // ("no permission") instead of a cascade of errors.
+        var presetPermissionLost = false;
+
+        try
+        {
+            await Task.Run(async () =>
+            {
+                var current = 0;
+                foreach (var game in gamesToProcess)
+                {
+                    ++current;
+                    ((IProgress<int>)progress).Report(current);
+
+                    // Covers scans that were already running when the batch started.
+                    // Emit one skipped result PER planned action so per-action counters stay correct.
+                    if (game.Processing == true)
+                    {
+                        foreach (var dllAction in dllActions)
+                        {
+                            results.Add(SkippedResult(game, dllAction.Label, "GamesPage_Batch_Skipped_Processing"));
+                        }
+                        foreach (var presetAction in presetActions)
+                        {
+                            results.Add(SkippedResult(game, presetAction.Label, "GamesPage_Batch_Skipped_Processing"));
+                        }
+                        continue;
+                    }
+
+                    // DLL actions first, in type order (so a same-type preset applies over the swapped DLL).
+                    foreach (var dllAction in dllActions)
+                    {
+                        try
+                        {
+                            // Re-checked per action: a scan starting mid-batch mutates
+                            // GameAssets, which GetBatchCompatibility reads. The residual
+                            // race degrades to an ErrorResult via this try, never a crash.
+                            if (game.Processing == true)
+                            {
+                                results.Add(SkippedResult(game, dllAction.Label, "GamesPage_Batch_Skipped_Processing"));
+                                continue;
+                            }
+
+                            var compatibility = DLLManager.GetBatchCompatibility(game, dllAction.Record);
+                            if (compatibility.Compatible == false)
+                            {
+                                results.Add(SkippedResult(game, dllAction.Label, compatibility.ReasonKey));
+                                continue;
+                            }
+
+                            var didUpdate = await game.UpdateDllAsync(dllAction.Record);
+                            if (didUpdate.Success == true)
+                            {
+                                results.Add(SwappedResult(game, dllAction.Label));
+                            }
+                            else
+                            {
+                                results.Add(ErrorResult(game, dllAction.Label, didUpdate.Message, didUpdate.PromptToRelaunchAsAdmin));
+                            }
+                        }
+                        catch (Exception err)
+                        {
+                            Logger.Error(err, $"Batch swap failed for \"{game.Title}\".");
+                            results.Add(ErrorResult(game, dllAction.Label, err.Message, false));
+                        }
+                    }
+
+                    // Preset actions after DLL actions. NVAPI is only ever exercised on
+                    // the UI thread (see GameControlModel), so marshal each call there.
+                    foreach (var presetAction in presetActions)
+                    {
+                        if (presetPermissionLost == true)
+                        {
+                            results.Add(SkippedResult(game, presetAction.Label, "GamesPage_Batch_Preset_Skipped_Unsupported"));
+                            continue;
+                        }
+
+                        try
+                        {
+                            var outcome = await RunOnUiAsync(() => ApplyPreset(game, presetAction.Type, presetAction.PresetValue));
+                            switch (outcome)
+                            {
+                                case PresetOutcome.Set:
+                                    results.Add(SwappedResult(game, presetAction.Label));
+                                    break;
+                                case PresetOutcome.SkippedNoAsset:
+                                    results.Add(SkippedResult(game, presetAction.Label, "GamesPage_Batch_Preset_Skipped_NoAsset"));
+                                    break;
+                                case PresetOutcome.SkippedNoProfile:
+                                    results.Add(SkippedResult(game, presetAction.Label, "GamesPage_Batch_Preset_Skipped_NoProfile"));
+                                    break;
+                                case PresetOutcome.SkippedUnsupported:
+                                    results.Add(SkippedResult(game, presetAction.Label, "GamesPage_Batch_Preset_Skipped_Unsupported"));
+                                    break;
+                                default:
+                                    results.Add(ErrorResult(game, presetAction.Label, string.Empty, false));
+                                    break;
+                            }
+                        }
+                        catch (Exception err)
+                        {
+                            Logger.Error(err, $"Batch swap failed for \"{game.Title}\".");
+                            results.Add(ErrorResult(game, presetAction.Label, err.Message, false));
+                        }
+
+                        // A permission failure flips IsSupported off — stop trying presets.
+                        if (NVAPIHelper.Instance.IsSupported == false)
+                        {
+                            presetPermissionLost = true;
+                        }
+                    }
+                }
+            });
+        }
+        finally
+        {
+            // Ensures the non-dismissible progress dialog is never stranded.
+            progressDialog.Hide();
+        }
+
+        // 4. Summary (flat list, one line per game+action).
+        var summaryDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetString("GamesPage_Batch_SummaryTitle"),
+            CloseButtonText = ResourceHelper.GetString("General_Close"),
+            DefaultButton = ContentDialogButton.Close,
+            Content = new BatchSwapSummaryControl(results),
+        };
+        await summaryDialog.ShowAsync();
+
+        // 5. Leave selection mode.
+        if (IsSelectionMode == true)
+        {
+            ToggleSelectionMode();
+        }
+    }
+
+    // Applies a single preset to a single game. MUST run on the UI thread:
+    // GameAssets is a UI-thread collection and NVAPI's DriverSettingsSession is
+    // only ever written from the UI thread (mirrors GameControlModel).
+    PresetOutcome ApplyPreset(Game game, GameAssetType type, uint presetValue)
+    {
+        if (game.GameAssets.Any(x => x.AssetType == type) == false)
+        {
+            return PresetOutcome.SkippedNoAsset;
+        }
+
+        if (NVAPIHelper.Instance.IsSupported == false)
+        {
+            return PresetOutcome.SkippedUnsupported;
+        }
+
+        if (NVAPIHelper.Instance.FindGameProfile(game) is null)
+        {
+            return PresetOutcome.SkippedNoProfile;
+        }
+
+        // NOTE: DLL type — only these three support presets. Read .Success only:
+        // SetGameDLSSDPreset/SetGameDLSSGPreset return Result == false even on success.
+        var success = type switch
+        {
+            GameAssetType.DLSS => NVAPIHelper.Instance.SetGameDLSSPreset(game, presetValue).Success,
+            GameAssetType.DLSS_D => NVAPIHelper.Instance.SetGameDLSSDPreset(game, presetValue).Success,
+            GameAssetType.DLSS_G => NVAPIHelper.Instance.SetGameDLSSGPreset(game, presetValue).Success,
+            _ => false,
+        };
+
+        return success ? PresetOutcome.Set : PresetOutcome.Error;
+    }
+
+    // Runs func on the page's UI thread and awaits its result. TryEnqueue's default
+    // priority avoids the CS0104 DispatcherQueuePriority ambiguity (this file has
+    // `using Windows.System;`).
+    Task<T> RunOnUiAsync<T>(Func<T> func)
+    {
+        var tcs = new TaskCompletionSource<T>();
+        var enqueued = gameGridPage.DispatcherQueue.TryEnqueue(() =>
+        {
+            try
+            {
+                tcs.SetResult(func());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+
+        // If the queue rejected the work (e.g. shutdown) the callback never runs;
+        // fail the task so the batch worker is never left awaiting forever.
+        if (enqueued == false)
+        {
+            tcs.TrySetException(new InvalidOperationException("Could not enqueue work on the UI thread."));
+        }
+        return tcs.Task;
+    }
+
+    static BatchSwapResult SwappedResult(Game game, string actionLabel) =>
+        new BatchSwapResult() { GameTitle = game.Title, Status = BatchSwapStatus.Swapped, ActionLabel = actionLabel };
+
+    static BatchSwapResult SkippedResult(Game game, string actionLabel, string reasonKey) =>
+        new BatchSwapResult() { GameTitle = game.Title, Status = BatchSwapStatus.Skipped, ActionLabel = actionLabel, ReasonKey = reasonKey };
+
+    static BatchSwapResult ErrorResult(Game game, string actionLabel, string errorMessage, bool promptToRelaunchAsAdmin) =>
+        new BatchSwapResult() { GameTitle = game.Title, Status = BatchSwapStatus.Error, ActionLabel = actionLabel, ErrorMessage = errorMessage, PromptToRelaunchAsAdmin = promptToRelaunchAsAdmin };
+
+    async Task<bool> EnsureDownloadedAsync(DLLRecord dllRecord)
+    {
+        var isInFlight = dllRecord.LocalRecord?.FileDownloader is not null;
+
+        var downloadStackPanel = new StackPanel()
+        {
+            Spacing = 16,
+            Orientation = Orientation.Vertical,
+            Children =
+            {
+                new ProgressBar() { IsIndeterminate = true },
+            },
+        };
+        if (isInFlight == true)
+        {
+            downloadStackPanel.Children.Add(new TextBlock()
+            {
+                Text = ResourceHelper.GetString("GamesPage_Batch_WaitingForDownload"),
+                TextWrapping = TextWrapping.Wrap,
+            });
+        }
+
+        var downloadDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+        {
+            Title = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_DownloadingTemplate", dllRecord.DisplayName),
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            Content = downloadStackPanel,
+        };
+
+        // IMPORTANT: DownloadAsync cancels the previous CancellationTokenSource on
+        // entry (DLLRecord.cs:275). If a download for this record is already in
+        // flight (started from the Library page) we must wait for it instead of
+        // calling DownloadAsync again.
+        var downloadTask = isInFlight ? WaitForInFlightDownloadAsync(dllRecord) : dllRecord.DownloadAsync();
+
+        // For a download this batch started, Cancel aborts the download itself.
+        // For a download the Library page started, Cancel abandons only OUR wait —
+        // the other surface's download keeps running. WaitForInFlightDownloadAsync
+        // unsubscribes itself when that download eventually finishes.
+        var abandonWaitTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        downloadDialog.CloseButtonClick += (sender, args) =>
+        {
+            if (isInFlight == true)
+            {
+                abandonWaitTcs.TrySetResult(true);
+            }
+            else
+            {
+                dllRecord.CancelDownload();
+            }
+        };
+
+        _ = downloadDialog.ShowAsync();
+
+        (bool Success, string Message, bool Cancelled) downloadResult;
+        if (isInFlight == true)
+        {
+            var completedTask = await Task.WhenAny(downloadTask, abandonWaitTcs.Task);
+            downloadResult = completedTask == downloadTask ? await downloadTask : (false, string.Empty, true);
+        }
+        else
+        {
+            downloadResult = await downloadTask;
+        }
+        downloadDialog.Hide();
+
+        if (downloadResult.Cancelled == true)
+        {
+            return false;
+        }
+
+        if (downloadResult.Success == false)
+        {
+            var errorDialog = new EasyContentDialog(gameGridPage.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Close"),
+                DefaultButton = ContentDialogButton.Close,
+                Content = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_DownloadFailedTemplate", dllRecord.DisplayName),
+            };
+            await errorDialog.ShowAsync();
+            return false;
+        }
+
+        return true;
+    }
+
+    // There is no exposed Task for an in-flight download, so completion is observed
+    // via DLLRecord's PropertyChanged: success sets IsDownloaded before the finally
+    // block clears FileDownloader; error sets HasDownloadError; cancellation clears
+    // FileDownloader with neither flag set. All notifications arrive on the UI thread.
+    static Task<(bool Success, string Message, bool Cancelled)> WaitForInFlightDownloadAsync(DLLRecord dllRecord)
+    {
+        var tcs = new TaskCompletionSource<(bool Success, string Message, bool Cancelled)>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        void ResolveIfFinished()
+        {
+            var localRecord = dllRecord.LocalRecord;
+            if (localRecord is null)
+            {
+                return;
+            }
+
+            if (localRecord.IsDownloaded == true)
+            {
+                tcs.TrySetResult((true, string.Empty, false));
+            }
+            else if (localRecord.FileDownloader is null)
+            {
+                if (localRecord.HasDownloadError == true)
+                {
+                    tcs.TrySetResult((false, localRecord.DownloadErrorMessage, false));
+                }
+                else
+                {
+                    tcs.TrySetResult((false, string.Empty, true));
+                }
+            }
+        }
+
+        PropertyChangedEventHandler handler = (sender, e) => ResolveIfFinished();
+        dllRecord.PropertyChanged += handler;
+
+        // The download may have finished between the caller's check and our subscription.
+        ResolveIfFinished();
+
+        return tcs.Task.ContinueWith(t =>
+        {
+            dllRecord.PropertyChanged -= handler;
+            return t.Result;
+        }, TaskScheduler.Default);
+    }
+
+    internal void UpdateSelection(IList<object> addedItems, IList<object> removedItems)
+    {
+        foreach (var item in removedItems)
+        {
+            if (item is Game game)
+            {
+                SelectedGames.Remove(game);
+            }
+        }
+
+        foreach (var item in addedItems)
+        {
+            if (item is Game game && SelectedGames.Contains(game) == false)
+            {
+                SelectedGames.Add(game);
+            }
+        }
+
+        NotifySelectionChanged();
+    }
+
+    void NotifySelectionChanged()
+    {
+        OnPropertyChanged(nameof(SelectedGamesCountText));
+        OnPropertyChanged(nameof(SelectAllButtonText));
+        OnPropertyChanged(nameof(CanApplyBatchDll));
+        ApplyBatchDllCommand.NotifyCanExecuteChanged();
+    }
 
     public GameGridPageModel(GameGridPage gameGridPage)
     {
@@ -95,12 +649,26 @@ public partial class GameGridPageModel : ObservableObject
             throw new ArgumentException("Sender must be a TextBox");
         }
 
+        if (IsSelectionMode == true)
+        {
+            // Swapping ItemsSource clears the control's visual selection and fires
+            // spurious SelectionChanged events (see the note in ApplyGameGroupFilter).
+            gameGridPage.BeginSuppressSelectionEvents();
+        }
+
         if (string.IsNullOrEmpty(textBox.Text))
         {
             CurrentCollectionView = GameManager.Instance.GetGameCollection();
-            return;
         }
-        CurrentCollectionView = GameManager.Instance.GetGameCollection(textBox.Text);
+        else
+        {
+            CurrentCollectionView = GameManager.Instance.GetGameCollection(textBox.Text);
+        }
+
+        if (IsSelectionMode == true)
+        {
+            gameGridPage.ResyncVisualSelectionAfterViewChange();
+        }
     }
 
     [RelayCommand]
@@ -359,3 +927,16 @@ public partial class GameGridPageModel : ObservableObject
         Settings.Instance.GameGridViewType = gameGridView;
     }
 }
+
+enum PresetOutcome
+{
+    Set,
+    Error,
+    SkippedNoAsset,
+    SkippedNoProfile,
+    SkippedUnsupported,
+}
+
+readonly record struct BatchDllActionItem(GameAssetType Type, DLLRecord Record, string Label);
+
+readonly record struct BatchPresetActionItem(GameAssetType Type, uint PresetValue, string Label);

--- a/src/Pages/GameGridPageModelTranslationProperties.cs
+++ b/src/Pages/GameGridPageModelTranslationProperties.cs
@@ -35,4 +35,16 @@ public class GameGridPageModelTranslationProperties : LocalizedViewModelBase
 
     [TranslationProperty]
     public string ApplicationRunsInAdministrativeModeInfo => ResourceHelper.GetString("General_ApplicationRunningAsAdmin");
+
+    [TranslationProperty]
+    public string SelectText => ResourceHelper.GetString("GamesPage_Select");
+
+    [TranslationProperty]
+    public string ApplyDllText => ResourceHelper.GetString("GamesPage_ApplyDll");
+
+    [TranslationProperty]
+    public string ClearText => ResourceHelper.GetString("General_Clear");
+
+    [TranslationProperty]
+    public string DoneText => ResourceHelper.GetString("GamesPage_SelectionMode_Done");
 }

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -367,6 +367,113 @@ To verify what preset is being used please enable the DLSS on-screen indicator.<
   <data name="GamesPage_AddGame" xml:space="preserve">
     <value>Add Game</value>
   </data>
+  <data name="GamesPage_ApplyDll" xml:space="preserve">
+    <value>Apply DLL</value>
+  </data>
+  <data name="GamesPage_Batch_ApplyingTemplate" xml:space="preserve">
+    <value>Applying… ({0} of {1})</value>
+  </data>
+  <data name="GamesPage_Batch_ColumnHeader_Preset" xml:space="preserve">
+    <value>Preset</value>
+    <comment>Column header above the preset dropdowns in the batch picker</comment>
+  </data>
+  <data name="GamesPage_Batch_ColumnHeader_Version" xml:space="preserve">
+    <value>Version</value>
+    <comment>Column header above the DLL version dropdowns in the batch picker</comment>
+  </data>
+  <data name="GamesPage_Batch_DllLabelTemplate" xml:space="preserve">
+    <value>{0} → {1}</value>
+    <comment>{0} = DLL type name (e.g. DLSS), {1} = DLL version display name</comment>
+  </data>
+  <data name="GamesPage_Batch_DownloadFailedTemplate" xml:space="preserve">
+    <value>Could not download {0}. No games were changed.</value>
+  </data>
+  <data name="GamesPage_Batch_DownloadingTemplate" xml:space="preserve">
+    <value>Downloading {0}…</value>
+  </data>
+  <data name="GamesPage_Batch_Error_Generic" xml:space="preserve">
+    <value>Failed (state possibly partial — verify this game)</value>
+  </data>
+  <data name="GamesPage_Batch_Error_PossiblyPartialTemplate" xml:space="preserve">
+    <value>{0} (state possibly partial — verify this game)</value>
+  </data>
+  <data name="GamesPage_Batch_Group_DLSS" xml:space="preserve">
+    <value>DLSS</value>
+  </data>
+  <data name="GamesPage_Batch_Group_FSR" xml:space="preserve">
+    <value>FSR</value>
+  </data>
+  <data name="GamesPage_Batch_Group_XeSS" xml:space="preserve">
+    <value>XeSS</value>
+  </data>
+  <data name="GamesPage_Batch_NeedsAdminTemplate" xml:space="preserve">
+    <value>{0} game(s) require running DLSS Swapper as administrator</value>
+  </data>
+  <data name="GamesPage_Batch_NoChange" xml:space="preserve">
+    <value>Don't change</value>
+  </data>
+  <data name="GamesPage_Batch_Preset_Skipped_NoAsset" xml:space="preserve">
+    <value>Game does not have this DLL</value>
+  </data>
+  <data name="GamesPage_Batch_Preset_Skipped_NoProfile" xml:space="preserve">
+    <value>No NVIDIA driver profile found for this game</value>
+  </data>
+  <data name="GamesPage_Batch_Preset_Skipped_Unsupported" xml:space="preserve">
+    <value>NVIDIA presets are not available</value>
+  </data>
+  <data name="GamesPage_Batch_Preset_UnsupportedMessage" xml:space="preserve">
+    <value>Presets are unavailable because no supported NVIDIA driver was detected on this system.</value>
+  </data>
+  <data name="GamesPage_Batch_PresetForTypeTemplate" xml:space="preserve">
+    <value>{0} preset</value>
+    <comment>Accessible name for a preset dropdown. {0} = DLL type name (e.g. DLSS)</comment>
+  </data>
+  <data name="GamesPage_Batch_PresetLabelTemplate" xml:space="preserve">
+    <value>Preset {0} → {1}</value>
+    <comment>{0} = DLL type name (e.g. DLSS), {1} = preset name (e.g. D)</comment>
+  </data>
+  <data name="GamesPage_Batch_Skipped_Incompatible" xml:space="preserve">
+    <value>Incompatible DLSS generation</value>
+  </data>
+  <data name="GamesPage_Batch_Skipped_MixedGenerations" xml:space="preserve">
+    <value>Game mixes DLSS generations</value>
+  </data>
+  <data name="GamesPage_Batch_Skipped_NoAsset" xml:space="preserve">
+    <value>Game does not use this DLL type</value>
+  </data>
+  <data name="GamesPage_Batch_Skipped_Processing" xml:space="preserve">
+    <value>Game is currently processing</value>
+  </data>
+  <data name="GamesPage_Batch_Summary_Errors" xml:space="preserve">
+    <value>Errors:</value>
+  </data>
+  <data name="GamesPage_Batch_Summary_NotApplicableTemplate" xml:space="preserve">
+    <value>{0} change(s) did not apply because the game does not use that DLL type.</value>
+    <comment>{0} = number of planned changes that were not applicable</comment>
+  </data>
+  <data name="GamesPage_Batch_Summary_Skipped" xml:space="preserve">
+    <value>Skipped:</value>
+  </data>
+  <data name="GamesPage_Batch_Summary_Swapped" xml:space="preserve">
+    <value>Swapped:</value>
+  </data>
+  <data name="GamesPage_Batch_Summary_SwappedTemplate" xml:space="preserve">
+    <value>{0} change(s) across {1} game(s)</value>
+    <comment>{0} = number of DLL/preset changes made, {1} = number of games they were made in</comment>
+  </data>
+  <data name="GamesPage_Batch_SummaryTitle" xml:space="preserve">
+    <value>Batch swap summary</value>
+  </data>
+  <data name="GamesPage_Batch_Title" xml:space="preserve">
+    <value>Apply DLL to selected games</value>
+  </data>
+  <data name="GamesPage_Batch_VersionForTypeTemplate" xml:space="preserve">
+    <value>{0} version</value>
+    <comment>Accessible name for a DLL version dropdown. {0} = DLL type name (e.g. DLSS)</comment>
+  </data>
+  <data name="GamesPage_Batch_WaitingForDownload" xml:space="preserve">
+    <value>Waiting for the current download to finish…</value>
+  </data>
   <data name="GamesPage_GroupGamesFromTheSameLibraryTogether" xml:space="preserve">
     <value>Group games from the same library together</value>
   </data>
@@ -452,6 +559,23 @@ If you have checked these and your game is still not showing up there may be a b
     <comment>Used as a loading box title when the user clicks reload game button on a games detail page</comment>
     <value>Reloading game</value>
   </data>
+  <data name="GamesPage_Select" xml:space="preserve">
+    <value>Select</value>
+  </data>
+  <data name="GamesPage_SelectionMode_CountTemplate" xml:space="preserve">
+    <value>{0} selected</value>
+  </data>
+  <data name="GamesPage_SelectionMode_DeselectAll" xml:space="preserve">
+    <comment>Button in the selection bar, shown when every currently visible game is already selected</comment>
+    <value>Deselect all</value>
+  </data>
+  <data name="GamesPage_SelectionMode_Done" xml:space="preserve">
+    <value>Done</value>
+  </data>
+  <data name="GamesPage_SelectionMode_SelectAll" xml:space="preserve">
+    <comment>Button in the selection bar, selects every game currently visible after filter and search</comment>
+    <value>Select all</value>
+  </data>
   <data name="GamesPage_ShowHiddenGamesText" xml:space="preserve">
     <value>Show hidden games (defaults to off on launch)</value>
   </data>
@@ -475,6 +599,9 @@ If you have checked these and your game is still not showing up there may be a b
   </data>
   <data name="General_Cancel" xml:space="preserve">
     <value>Cancel</value>
+  </data>
+  <data name="General_Clear" xml:space="preserve">
+    <value>Clear</value>
   </data>
   <data name="General_Close" xml:space="preserve">
     <value>Close</value>

--- a/src/UserControls/BatchDllPickerControl.xaml
+++ b/src/UserControls/BatchDllPickerControl.xaml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DLSS_Swapper.UserControls.BatchDllPickerControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:usercontrols="using:DLSS_Swapper.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ct_converters="using:CommunityToolkit.WinUI.Converters"
+    d:DataContext="{d:DesignInstance Type=usercontrols:BatchDllPickerControlModel, IsDesignTimeCreatable=True}"
+    mc:Ignorable="d"
+    MinWidth="600">
+
+    <UserControl.Resources>
+        <ct_converters:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" TrueValue="Visible" FalseValue="Collapsed" />
+    </UserControl.Resources>
+
+    <!-- Tall enough for every DLL type at once; the scroll bar is only there for
+         short displays, where the dialog itself gets capped by the window. -->
+    <ScrollViewer VerticalScrollMode="Auto" VerticalScrollBarVisibility="Auto" HorizontalScrollMode="Disabled" MaxHeight="640">
+        <!-- Stays under ContentDialogMaxWidth minus the dialog padding and the
+             scroll bar, otherwise the right-hand combos get clipped. -->
+        <StackPanel Orientation="Vertical" Spacing="20" MinWidth="600">
+
+            <!-- DLSS group (always shown; presets live here) -->
+            <StackPanel Orientation="Vertical" Spacing="8">
+                <TextBlock Text="{x:Bind ViewModel.TranslationProperties.DlssGroupText, Mode=OneWay}" Style="{ThemeResource SubtitleTextBlockStyle}" />
+
+                <!-- Only this group has two combos per row, so without headers there is
+                     nothing telling the version dropdown apart from the preset one. -->
+                <Grid ColumnSpacing="12">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="180" />
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="1.3*" />
+                    </Grid.ColumnDefinitions>
+                    <TextBlock Grid.Column="1" Text="{x:Bind ViewModel.TranslationProperties.VersionColumnText, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                    <TextBlock Grid.Column="2" Text="{x:Bind ViewModel.TranslationProperties.PresetColumnText, Mode=OneWay}" Style="{ThemeResource CaptionTextBlockStyle}" Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
+                </Grid>
+
+                <TextBlock Text="{x:Bind ViewModel.TranslationProperties.PresetsUnsupportedText, Mode=OneWay}"
+                           TextWrapping="Wrap"
+                           Style="{ThemeResource CaptionTextBlockStyle}"
+                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                           Visibility="{x:Bind ViewModel.PresetsUnsupported, Converter={StaticResource BoolToVisibilityConverter}}" />
+
+                <ItemsControl ItemsSource="{x:Bind ViewModel.DlssRows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="usercontrols:BatchDllRowModel">
+                            <Grid ColumnSpacing="12" Padding="0,4" HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <!-- Same width in all three groups so the version combos line up. -->
+                                    <ColumnDefinition Width="180" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="1.3*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{x:Bind TypeName}" FontWeight="SemiBold" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                <ComboBox Grid.Column="1" HorizontalAlignment="Stretch"
+                                          AutomationProperties.Name="{x:Bind DllAutomationName}"
+                                          ItemsSource="{x:Bind DllOptions}"
+                                          DisplayMemberPath="DisplayName"
+                                          SelectedItem="{x:Bind SelectedDllOption, Mode=TwoWay}" />
+                                <ComboBox Grid.Column="2" HorizontalAlignment="Stretch"
+                                          AutomationProperties.Name="{x:Bind PresetAutomationName}"
+                                          ItemsSource="{x:Bind PresetOptions}"
+                                          DisplayMemberPath="Name"
+                                          SelectedItem="{x:Bind SelectedPreset, Mode=TwoWay}"
+                                          IsEnabled="{x:Bind PresetEnabled}" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- FSR group (hidden when no versions available) -->
+            <StackPanel Orientation="Vertical" Spacing="8" Visibility="{x:Bind ViewModel.HasFsrRows, Converter={StaticResource BoolToVisibilityConverter}}">
+                <TextBlock Text="{x:Bind ViewModel.TranslationProperties.FsrGroupText, Mode=OneWay}" Style="{ThemeResource SubtitleTextBlockStyle}" />
+                <ItemsControl ItemsSource="{x:Bind ViewModel.FsrRows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="usercontrols:BatchDllRowModel">
+                            <Grid ColumnSpacing="12" Padding="0,4" HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <!-- Same width in all three groups so the version combos line up. -->
+                                    <ColumnDefinition Width="180" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="1.3*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{x:Bind TypeName}" FontWeight="SemiBold" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                <ComboBox Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Stretch"
+                                          AutomationProperties.Name="{x:Bind DllAutomationName}"
+                                          ItemsSource="{x:Bind DllOptions}"
+                                          DisplayMemberPath="DisplayName"
+                                          SelectedItem="{x:Bind SelectedDllOption, Mode=TwoWay}" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+            <!-- XeSS group (hidden when no versions available) -->
+            <StackPanel Orientation="Vertical" Spacing="8" Visibility="{x:Bind ViewModel.HasXeSSRows, Converter={StaticResource BoolToVisibilityConverter}}">
+                <TextBlock Text="{x:Bind ViewModel.TranslationProperties.XessGroupText, Mode=OneWay}" Style="{ThemeResource SubtitleTextBlockStyle}" />
+                <ItemsControl ItemsSource="{x:Bind ViewModel.XeSSRows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="usercontrols:BatchDllRowModel">
+                            <Grid ColumnSpacing="12" Padding="0,4" HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <!-- Same width in all three groups so the version combos line up. -->
+                                    <ColumnDefinition Width="180" />
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="1.3*" />
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Grid.Column="0" Text="{x:Bind TypeName}" FontWeight="SemiBold" VerticalAlignment="Center" TextWrapping="Wrap" />
+                                <ComboBox Grid.Column="1" Grid.ColumnSpan="2" HorizontalAlignment="Stretch"
+                                          AutomationProperties.Name="{x:Bind DllAutomationName}"
+                                          ItemsSource="{x:Bind DllOptions}"
+                                          DisplayMemberPath="DisplayName"
+                                          SelectedItem="{x:Bind SelectedDllOption, Mode=TwoWay}" />
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </StackPanel>
+
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/UserControls/BatchDllPickerControl.xaml.cs
+++ b/src/UserControls/BatchDllPickerControl.xaml.cs
@@ -1,0 +1,15 @@
+using Microsoft.UI.Xaml.Controls;
+
+namespace DLSS_Swapper.UserControls;
+
+public sealed partial class BatchDllPickerControl : UserControl
+{
+    internal BatchDllPickerControlModel ViewModel { get; }
+
+    public BatchDllPickerControl(EasyContentDialog parentDialog)
+    {
+        this.InitializeComponent();
+        ViewModel = new BatchDllPickerControlModel(parentDialog);
+        DataContext = ViewModel;
+    }
+}

--- a/src/UserControls/BatchDllPickerControlModel.cs
+++ b/src/UserControls/BatchDllPickerControlModel.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DLSS_Swapper.Data;
+using DLSS_Swapper.Data.DLSS;
+using DLSS_Swapper.Helpers;
+
+namespace DLSS_Swapper.UserControls;
+
+public partial class BatchDllPickerControlModel : ObservableObject
+{
+    readonly WeakReference<EasyContentDialog> _parentDialogWeakReference;
+
+    public List<BatchDllRowModel> DlssRows { get; }
+    public List<BatchDllRowModel> FsrRows { get; }
+    public List<BatchDllRowModel> XeSSRows { get; }
+
+    public bool HasFsrRows => FsrRows.Count > 0;
+    public bool HasXeSSRows => XeSSRows.Count > 0;
+
+    // Drives the explanation shown when every preset combo is disabled. Without it
+    // the user just sees three greyed-out dropdowns and no reason why.
+    public bool PresetsUnsupported { get; }
+
+    public BatchDllPickerControlModelTranslationProperties TranslationProperties { get; } = new BatchDllPickerControlModelTranslationProperties();
+
+    public BatchDllPickerControlModel(EasyContentDialog parentDialog)
+    {
+        _parentDialogWeakReference = new WeakReference<EasyContentDialog>(parentDialog);
+        parentDialog.IsPrimaryButtonEnabled = false;
+
+        var noChangeText = ResourceHelper.GetString("GamesPage_Batch_NoChange");
+        var presetSupported = NVAPIHelper.Instance.IsSupported;
+        PresetsUnsupported = presetSupported == false;
+
+        // NOTE: DLL type
+        // Preset rows are always shown (a preset is useful even with no downloaded
+        // DLL). Each preset type uses its OWN option list.
+        DlssRows = new List<BatchDllRowModel>
+        {
+            BuildPresetRow(GameAssetType.DLSS, noChangeText, NVAPIHelper.Instance.DlssPresetOptions, presetSupported),
+            BuildPresetRow(GameAssetType.DLSS_D, noChangeText, NVAPIHelper.Instance.DlssDPresetOptions, presetSupported),
+            BuildPresetRow(GameAssetType.DLSS_G, noChangeText, NVAPIHelper.Instance.DlssGPresetOptions, presetSupported),
+        };
+
+        // DLL-only rows only appear when at least one DLL version is available.
+        FsrRows = BuildDllOnlyRows(noChangeText, new[] { GameAssetType.FSR_31_DX12, GameAssetType.FSR_31_VK });
+        XeSSRows = BuildDllOnlyRows(noChangeText, new[] { GameAssetType.XeSS, GameAssetType.XeSS_FG, GameAssetType.XeSS_DX11, GameAssetType.XeLL });
+
+        foreach (var row in AllRows())
+        {
+            row.PropertyChanged += Row_PropertyChanged;
+        }
+    }
+
+    BatchDllRowModel BuildPresetRow(GameAssetType type, string noChangeText, IReadOnlyList<PresetOption> presetOptions, bool presetEnabled)
+    {
+        var options = BuildDllOptions(type, noChangeText);
+        // Sentinel value 0xFFFFFFFF is not a real preset (PresetOption.UpdateNameFromTranslation
+        // leaves unknown values untouched), so it never collides with Default (0).
+        var sentinel = new PresetOption(noChangeText, 0xFFFFFFFF);
+        return new BatchDllRowModel(type, DLLManager.Instance.GetAssetTypeName(type), options, sentinel, presetOptions, presetEnabled);
+    }
+
+    List<BatchDllRowModel> BuildDllOnlyRows(string noChangeText, GameAssetType[] types)
+    {
+        var rows = new List<BatchDllRowModel>();
+        foreach (var type in types)
+        {
+            var options = BuildDllOptions(type, noChangeText);
+            // options[0] is the sentinel; a real version exists only if count > 1.
+            if (options.Count <= 1)
+            {
+                continue;
+            }
+            rows.Add(new BatchDllRowModel(type, DLLManager.Instance.GetAssetTypeName(type), options, null, null, false));
+        }
+        return rows;
+    }
+
+    static List<BatchDllOption> BuildDllOptions(GameAssetType type, string noChangeText)
+    {
+        // NOTE: DLL type
+        var records = type switch
+        {
+            GameAssetType.DLSS => DLLManager.Instance.DLSSRecords.ToList(),
+            GameAssetType.DLSS_G => DLLManager.Instance.DLSSGRecords.ToList(),
+            GameAssetType.DLSS_D => DLLManager.Instance.DLSSDRecords.ToList(),
+            GameAssetType.FSR_31_DX12 => DLLManager.Instance.FSR31DX12Records.ToList(),
+            GameAssetType.FSR_31_VK => DLLManager.Instance.FSR31VKRecords.ToList(),
+            GameAssetType.XeSS => DLLManager.Instance.XeSSRecords.ToList(),
+            GameAssetType.XeSS_DX11 => DLLManager.Instance.XeSSDX11Records.ToList(),
+            GameAssetType.XeSS_FG => DLLManager.Instance.XeSSFGRecords.ToList(),
+            GameAssetType.XeLL => DLLManager.Instance.XeLLRecords.ToList(),
+            _ => new List<DLLRecord>(),
+        };
+
+        if (Settings.Instance.OnlyShowDownloadedDlls == true)
+        {
+            records.RemoveAll(x => x.LocalRecord?.IsDownloaded != true);
+        }
+
+        if (Settings.Instance.AllowDebugDlls == false)
+        {
+            records.RemoveAll(x => x.IsDevFile == true);
+        }
+
+        // Only records with a LocalRecord can ever be applied (the executor needs
+        // LocalRecord before it can download). Dropping the rest here keeps the
+        // PlannedDllActions invariant: every planned record has a LocalRecord.
+        records.RemoveAll(x => x.LocalRecord is null);
+
+        var options = new List<BatchDllOption>
+        {
+            new BatchDllOption { DisplayName = noChangeText, Record = null },
+        };
+        options.AddRange(records.Select(r => new BatchDllOption { DisplayName = r.DisplayName, Record = r }));
+        return options;
+    }
+
+    void Row_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(BatchDllRowModel.SelectedDllOption) || e.PropertyName == nameof(BatchDllRowModel.SelectedPreset))
+        {
+            if (_parentDialogWeakReference.TryGetTarget(out var dialog) == true)
+            {
+                dialog.IsPrimaryButtonEnabled = AllRows().Any(r => r.HasDllAction || r.HasPresetAction);
+            }
+        }
+    }
+
+    IEnumerable<BatchDllRowModel> AllRows() => DlssRows.Concat(FsrRows).Concat(XeSSRows);
+
+    // What the picker decides — never *who* it applies to.
+    public List<(GameAssetType Type, DLLRecord Record)> PlannedDllActions =>
+        AllRows()
+            .Where(r => r.HasDllAction)
+            .Select(r => (r.Type, r.SelectedDllOption!.Record!))
+            .ToList();
+
+    public List<(GameAssetType Type, PresetOption Preset)> PlannedPresetActions =>
+        AllRows()
+            .Where(r => r.HasPresetAction)
+            .Select(r => (r.Type, r.SelectedPreset!))
+            .ToList();
+}

--- a/src/UserControls/BatchDllPickerControlModelTranslationProperties.cs
+++ b/src/UserControls/BatchDllPickerControlModelTranslationProperties.cs
@@ -1,0 +1,26 @@
+using DLSS_Swapper.Attributes;
+using DLSS_Swapper.Helpers;
+using DLSS_Swapper.Interfaces;
+
+namespace DLSS_Swapper.UserControls;
+
+public class BatchDllPickerControlModelTranslationProperties : LocalizedViewModelBase
+{
+    [TranslationProperty]
+    public string DlssGroupText => ResourceHelper.GetString("GamesPage_Batch_Group_DLSS");
+
+    [TranslationProperty]
+    public string FsrGroupText => ResourceHelper.GetString("GamesPage_Batch_Group_FSR");
+
+    [TranslationProperty]
+    public string XessGroupText => ResourceHelper.GetString("GamesPage_Batch_Group_XeSS");
+
+    [TranslationProperty]
+    public string VersionColumnText => ResourceHelper.GetString("GamesPage_Batch_ColumnHeader_Version");
+
+    [TranslationProperty]
+    public string PresetColumnText => ResourceHelper.GetString("GamesPage_Batch_ColumnHeader_Preset");
+
+    [TranslationProperty]
+    public string PresetsUnsupportedText => ResourceHelper.GetString("GamesPage_Batch_Preset_UnsupportedMessage");
+}

--- a/src/UserControls/BatchDllRowModel.cs
+++ b/src/UserControls/BatchDllRowModel.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using CommunityToolkit.Mvvm.ComponentModel;
+using DLSS_Swapper.Data;
+using DLSS_Swapper.Data.DLSS;
+using DLSS_Swapper.Helpers;
+
+namespace DLSS_Swapper.UserControls;
+
+// One selectable DLL version inside a batch picker row. A null Record is the
+// "Don't change" sentinel that leaves this row's DLL untouched.
+public class BatchDllOption
+{
+    public string DisplayName { get; init; } = string.Empty;
+    public DLLRecord? Record { get; init; }
+}
+
+// A single type row (DLSS, FSR_31_VK, ...). Holds its own DLL-version options and,
+// for the three preset-capable types, its own preset options. "Don't change" is
+// represented by presence of the sentinel selection, never by a uint value — so
+// preset 0 ("Default") stays a real, selectable action.
+public partial class BatchDllRowModel : ObservableObject
+{
+    public GameAssetType Type { get; }
+    public string TypeName { get; }
+
+    // TypeName is only a visual label in the row Grid, so the combos would otherwise
+    // reach Narrator unnamed. Both combos in a row need distinct names.
+    public string DllAutomationName { get; }
+    public string PresetAutomationName { get; }
+
+    // True for DLSS / DLSS_D / DLSS_G.
+    public bool HasPreset { get; }
+
+    // HasPreset && NVAPI supported. When false the preset combo shows only the
+    // sentinel and is disabled.
+    public bool PresetEnabled { get; }
+
+    // DllOptions[0] is always the sentinel (Record == null).
+    public List<BatchDllOption> DllOptions { get; }
+
+    // PresetOptions[0] is the sentinel when HasPreset; empty otherwise.
+    public List<PresetOption> PresetOptions { get; }
+
+    readonly PresetOption? _presetSentinel;
+
+    [ObservableProperty]
+    public partial BatchDllOption? SelectedDllOption { get; set; }
+
+    [ObservableProperty]
+    public partial PresetOption? SelectedPreset { get; set; }
+
+    public BatchDllRowModel(GameAssetType type, string typeName, List<BatchDllOption> dllOptions, PresetOption? presetSentinel, IReadOnlyList<PresetOption>? presetOptions, bool presetEnabled)
+    {
+        Type = type;
+        TypeName = typeName;
+        DllAutomationName = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_VersionForTypeTemplate", typeName);
+        PresetAutomationName = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_PresetForTypeTemplate", typeName);
+        DllOptions = dllOptions;
+        SelectedDllOption = dllOptions.FirstOrDefault(); // sentinel
+
+        HasPreset = presetSentinel is not null;
+        PresetEnabled = presetEnabled;
+        _presetSentinel = presetSentinel;
+
+        var options = new List<PresetOption>();
+        if (presetSentinel is not null)
+        {
+            options.Add(presetSentinel);
+            if (presetOptions is not null)
+            {
+                options.AddRange(presetOptions);
+            }
+        }
+        PresetOptions = options;
+        SelectedPreset = _presetSentinel;
+    }
+
+    public bool HasDllAction => SelectedDllOption?.Record is not null;
+
+    public bool HasPresetAction =>
+        HasPreset
+        && SelectedPreset is not null
+        && ReferenceEquals(SelectedPreset, _presetSentinel) == false;
+}

--- a/src/UserControls/BatchSwapSummaryControl.xaml
+++ b/src/UserControls/BatchSwapSummaryControl.xaml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<UserControl
+    x:Class="DLSS_Swapper.UserControls.BatchSwapSummaryControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:data="using:DLSS_Swapper.Data"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ct_converters="using:CommunityToolkit.WinUI.Converters"
+    mc:Ignorable="d"
+    MinWidth="400">
+
+    <UserControl.Resources>
+        <ct_converters:StringVisibilityConverter x:Key="StringVisibilityConverter" EmptyValue="Collapsed" NotEmptyValue="Visible" />
+    </UserControl.Resources>
+
+    <StackPanel Orientation="Vertical" Spacing="12">
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="{x:Bind ViewModel.TranslationProperties.SwappedText, Mode=OneWay}" FontWeight="Bold" />
+            <Run Text="{x:Bind ViewModel.SwappedSummaryText}" />
+        </TextBlock>
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="{x:Bind ViewModel.TranslationProperties.SkippedText, Mode=OneWay}" FontWeight="Bold" />
+            <Run Text="{x:Bind ViewModel.SkippedCount}" />
+        </TextBlock>
+        <TextBlock TextWrapping="Wrap">
+            <Run Text="{x:Bind ViewModel.TranslationProperties.ErrorsText, Mode=OneWay}" FontWeight="Bold" />
+            <Run Text="{x:Bind ViewModel.ErrorCount}" />
+        </TextBlock>
+
+        <!-- Secondary brush rather than Opacity: opacity is a render-level effect and
+             keeps dimming the text under Windows high contrast. -->
+        <TextBlock Text="{x:Bind ViewModel.NotApplicableMessage}" TextWrapping="Wrap" Foreground="{ThemeResource TextFillColorSecondaryBrush}" Visibility="{x:Bind ViewModel.NotApplicableMessage, Converter={StaticResource StringVisibilityConverter}}" />
+
+        <TextBlock Text="{x:Bind ViewModel.AdminMessage}" TextWrapping="Wrap" Visibility="{x:Bind ViewModel.AdminMessage, Converter={StaticResource StringVisibilityConverter}}" />
+
+        <ListView ItemsSource="{x:Bind ViewModel.Results}" SelectionMode="None" MaxHeight="300">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="data:BatchSwapResult">
+                    <TextBlock Text="{x:Bind DisplayText}" TextWrapping="Wrap" />
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </StackPanel>
+</UserControl>

--- a/src/UserControls/BatchSwapSummaryControl.xaml.cs
+++ b/src/UserControls/BatchSwapSummaryControl.xaml.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using DLSS_Swapper.Data;
+using Microsoft.UI.Xaml.Controls;
+
+namespace DLSS_Swapper.UserControls;
+
+public sealed partial class BatchSwapSummaryControl : UserControl
+{
+    BatchSwapSummaryControlModel ViewModel { get; }
+
+    public BatchSwapSummaryControl(IReadOnlyList<BatchSwapResult> results)
+    {
+        this.InitializeComponent();
+        ViewModel = new BatchSwapSummaryControlModel(results);
+        DataContext = ViewModel;
+    }
+}

--- a/src/UserControls/BatchSwapSummaryControlModel.cs
+++ b/src/UserControls/BatchSwapSummaryControlModel.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+using System.Linq;
+using DLSS_Swapper.Data;
+using DLSS_Swapper.Helpers;
+
+namespace DLSS_Swapper.UserControls;
+
+class BatchSwapSummaryControlModel
+{
+    // Skips that are expected rather than problems: the user asked for a DLL type
+    // the game simply doesn't ship. Listing one line per game+type buries the
+    // results that actually need attention, so these are collapsed into a count.
+    static readonly HashSet<string> NotApplicableReasonKeys = new HashSet<string>()
+    {
+        "GamesPage_Batch_Skipped_NoAsset",
+        "GamesPage_Batch_Preset_Skipped_NoAsset",
+        "GamesPage_Batch_Preset_Skipped_Unsupported",
+    };
+
+    public string SwappedSummaryText { get; } = string.Empty;
+    public int SkippedCount { get; }
+    public int ErrorCount { get; }
+    public string NotApplicableMessage { get; } = string.Empty;
+    public string AdminMessage { get; } = string.Empty;
+    public IReadOnlyList<BatchSwapResult> Results { get; }
+
+    public BatchSwapSummaryControlModelTranslationProperties TranslationProperties { get; } = new BatchSwapSummaryControlModelTranslationProperties();
+
+    public BatchSwapSummaryControlModel(IReadOnlyList<BatchSwapResult> results)
+    {
+        // Not-applicable skips are counted but kept out of the list.
+        Results = results.Where(x => x.Status != BatchSwapStatus.Skipped || NotApplicableReasonKeys.Contains(x.ReasonKey) == false).ToList();
+
+        var swapped = results.Where(x => x.Status == BatchSwapStatus.Swapped).ToList();
+        SwappedSummaryText = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_Summary_SwappedTemplate", swapped.Count, swapped.Select(x => x.GameTitle).Distinct().Count());
+
+        SkippedCount = results.Count(x => x.Status == BatchSwapStatus.Skipped && NotApplicableReasonKeys.Contains(x.ReasonKey) == false);
+        ErrorCount = results.Count(x => x.Status == BatchSwapStatus.Error);
+
+        var notApplicableCount = results.Count(x => x.Status == BatchSwapStatus.Skipped && NotApplicableReasonKeys.Contains(x.ReasonKey) == true);
+        if (notApplicableCount > 0)
+        {
+            NotApplicableMessage = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_Summary_NotApplicableTemplate", notApplicableCount);
+        }
+
+        var adminCount = results.Count(x => x.PromptToRelaunchAsAdmin == true);
+        if (adminCount > 0)
+        {
+            AdminMessage = ResourceHelper.GetFormattedResourceTemplate("GamesPage_Batch_NeedsAdminTemplate", adminCount);
+        }
+    }
+}

--- a/src/UserControls/BatchSwapSummaryControlModelTranslationProperties.cs
+++ b/src/UserControls/BatchSwapSummaryControlModelTranslationProperties.cs
@@ -1,0 +1,17 @@
+using DLSS_Swapper.Attributes;
+using DLSS_Swapper.Helpers;
+using DLSS_Swapper.Interfaces;
+
+namespace DLSS_Swapper.UserControls;
+
+public class BatchSwapSummaryControlModelTranslationProperties : LocalizedViewModelBase
+{
+    [TranslationProperty]
+    public string SwappedText => ResourceHelper.GetString("GamesPage_Batch_Summary_Swapped");
+
+    [TranslationProperty]
+    public string SkippedText => ResourceHelper.GetString("GamesPage_Batch_Summary_Skipped");
+
+    [TranslationProperty]
+    public string ErrorsText => ResourceHelper.GetString("GamesPage_Batch_Summary_Errors");
+}


### PR DESCRIPTION
## Description of Changes

Adds a selection mode to the games grid so several games can be updated in one operation, instead of opening each game individually.

### Flow

**1.** `Select` in the toolbar enters selection mode — cards become checkable and a bar appears with the selection count, `Select all`, `Apply DLL`, `Clear` and `Done`.

<img width="1480" height="1043" alt="Games grid in selection mode with six games selected" src="https://github.com/user-attachments/assets/43bd45fb-69cd-4870-b655-6eb34f11bcff" />

**2.** `Apply DLL` opens a picker listing every DLL type, each with a version dropdown, plus a preset dropdown for the three DLSS types. Every row defaults to *Don't change*, so nothing is touched unless it is explicitly chosen.

<img width="1576" height="1115" alt="Apply DLL dialog with a version and preset dropdown per DLL type" src="https://github.com/user-attachments/assets/4c4dbcf6-662a-469e-baac-69b5cd5879ad" />

**3.** Applying runs sequentially behind a progress dialog, then shows a summary: how many changes were made across how many games, how many were skipped, how many errored, and a separate count for changes that did not apply because a game does not ship that DLL type.

<img width="1479" height="1046" alt="Batch swap summary listing each change that was applied" src="https://github.com/user-attachments/assets/ff11ce6c-843b-4fc2-9479-7624484fd649" />

### Notable details

- The picker is game-agnostic — it offers what is downloaded locally, and per-game compatibility is resolved at apply time rather than by intersecting the selection up front. A game that cannot take a change is reported, not silently dropped.
- Results distinguish three outcomes: *swapped*, *skipped* (something the user may want to act on) and *error*. "Game does not use that DLL type" is collapsed into a single count so it does not bury the actionable lines.
- Failures that need elevation are aggregated into one "relaunch as admin" message rather than one per game.
- All user-facing strings go through `.resw` / `ResourceHelper`. **Only `en-US` is populated in this PR** — the other locales fall back until translated.
- No changes to `GameAssetType` numbering, the database schema, or the manifest.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Issues Resolved

Related to #157.

The design sketched in that issue is **not followed exactly** here — the differences I am aware of:

- selection is not persisted across app restarts
- no per-game opt-out inside the picker once games are selected
- `Select all` is a plain toggle rather than tri-state
- no bulk "reset to original DLL"

Happy to rework any of these, or to split the PR up, if the design in #157 is the direction you want to take. Opening it as a draft so there is something concrete to react to.

