### PR TITLE
Fixed update prompt never showing for a newer version

### DIFF
--- a/src/Data/GitHub/GitHubUpdater.cs
+++ b/src/Data/GitHub/GitHubUpdater.cs
@@ -158,7 +158,7 @@ internal class GitHubUpdater
         {
             return false;
         }
-        else if (thisVersion < lastVersionPromptedFor)
+        else if (thisVersion > lastVersionPromptedFor)
         {
             return false;
         }


### PR DESCRIPTION
## Description of Changes

`GitHubUpdater.HasPromptedBefore` has its comparison the wrong way round, so once the app has prompted about any release it never prompts again.

The method answers "have we already nagged the user about this version?". `MainWindow.xaml.cs:379` only shows the dialog when it returns `false`. As written it returns `false` when the available release is **older** than `Settings.Instance.LastPromptWasForVersion`, and `true` for every version **newer** than it, which is backwards:

```csharp
else if (thisVersion < lastVersionPromptedFor)
{
    return false;
}
```

That is the case in #924. A user on v1.2.5 already has `LastPromptWasForVersion` set to v1.2.5.0 from the previous prompt. v1.2.6.1 is greater than that, so the check reports "already prompted" and the dialog is skipped. The `LastPromptWasForVersion == 0` early return is why it still works exactly once, on a fresh install.

This is a one character change, `<` to `>`.

I also checked a second possible cause before settling on this one. `GitHubRelease.GetVersionNumber` returns 0 unless the release name starts with `v`, which would break the check a different way, but the API really does return `name=v1.2.6.1`, so parsing is fine.

### Evidence

I copied `GetVersionNumber` and `HasPromptedBefore` into a standalone console app and ran the real release names from the API. With `LastPromptWasForVersion` at v1.2.5.0:

| latest release | current: prompts? | patched: prompts? | should prompt? |
| --- | --- | --- | --- |
| v1.2.4.0 | yes | no | no |
| v1.2.5.0 | no | no | no |
| v1.2.6.1 | no | yes | yes |
| v1.3.0.0 | no | yes | yes |
| v2.0.0.0 | no | yes | yes |

The current code is wrong in four of the five cases, including every newer version. With the operator flipped all five are correct, and the first run case (`LastPromptWasForVersion == 0`) still prompts either way.

Builds clean, 0 warnings and 0 errors.

One thing I have not verified: the dialog actually appearing in a running app. That needs a real prompt cycle against a stale `LastPromptWasForVersion` and a newer published release, which I could not set up locally. The logic above is verified, the end to end UI path is not. Happy to test it another way if you would like.

This should also cover most of what #928 is about, since that describes the same "only prompts once" behaviour, though a persistent banner would still be a useful addition on top.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#924
