### PR TITLE
Fix Steam scan crash from updating UI-bound properties off the UI thread

### DIFF
--- a/src/Data/BattleNet/BattleNetLibrary.cs
+++ b/src/Data/BattleNet/BattleNetLibrary.cs
@@ -263,44 +263,52 @@ internal partial class BattleNetLibrary : IGameLibrary
                 var cachedGame = GameManager.Instance.GetGame<BattleNetGame>(gameId);
                 var activeGame = cachedGame ?? new BattleNetGame(gameId);
 
-                if (_knownGames.TryGetValue(product.Uid, out var battleNetLauncherGame))
+                // These are UI-bound properties. Once the SaveToDatabaseAsync().ConfigureAwait(false) below has run for
+                // an earlier game in this loop we are no longer on the UI thread, so these must be marshalled explicitly
+                // or WinUI throws RPC_E_WRONGTHREAD when a bound control is updated from a background thread.
+                await App.CurrentApp.RunOnUIThreadAsync(() =>
                 {
-                    activeGame.Title = battleNetLauncherGame.Name;
-                    activeGame.LauncherId = battleNetLauncherGame.LauncherId;
-                }
-                else
-                {
-                    Logger.Error($"Battle.Net game title not found for UID ({product.Uid}) in install path ({product.Settings.InstallPath}).");
-
-                    if (string.IsNullOrWhiteSpace(product.Settings.InstallPath))
+                    if (_knownGames.TryGetValue(product.Uid, out var battleNetLauncherGame))
                     {
-                        activeGame.Title = product.Uid;
+                        activeGame.Title = battleNetLauncherGame.Name;
+                        activeGame.LauncherId = battleNetLauncherGame.LauncherId;
                     }
                     else
                     {
-                        var directoryInfo = new DirectoryInfo(product.Settings.InstallPath);
-                        activeGame.Title = directoryInfo.Name;
-                    }
-                }
+                        Logger.Error($"Battle.Net game title not found for UID ({product.Uid}) in install path ({product.Settings.InstallPath}).");
 
-                if (installedAggregates.TryGetValue(product.ProductCode, out var aggregate))
-                {
-                    // If title isn't set, try use it from the aggregates.
-                    if (string.IsNullOrWhiteSpace(activeGame.Title))
+                        if (string.IsNullOrWhiteSpace(product.Settings.InstallPath))
+                        {
+                            activeGame.Title = product.Uid;
+                        }
+                        else
+                        {
+                            var directoryInfo = new DirectoryInfo(product.Settings.InstallPath);
+                            activeGame.Title = directoryInfo.Name;
+                        }
+                    }
+
+                    if (installedAggregates.TryGetValue(product.ProductCode, out var aggregate))
                     {
-                        activeGame.Title = aggregate.Name;
+                        // If title isn't set, try use it from the aggregates.
+                        if (string.IsNullOrWhiteSpace(activeGame.Title))
+                        {
+                            activeGame.Title = aggregate.Name;
+                        }
+
+                        // Set the cover photo.
+                        activeGame.RemoteCoverImage = aggregate.LogoArtUri;
+                    }
+                    else
+                    {
+                        Logger.Error($"Battle.Net game aggregate not found for ProductCode ({product.ProductCode}).");
                     }
 
-                    // Set the cover photo.
-                    activeGame.RemoteCoverImage = aggregate.LogoArtUri;
-                }
-                else
-                {
-                    Logger.Error($"Battle.Net game aggregate not found for ProductCode ({product.ProductCode}).");
-                }
+                    activeGame.InstallPath = PathHelpers.NormalizePath(gamePath);
+                    activeGame.StatePlayable = product.CachedProductState.BaseProductState.Playable;
 
-                activeGame.InstallPath = PathHelpers.NormalizePath(gamePath);
-                activeGame.StatePlayable = product.CachedProductState.BaseProductState.Playable;
+                    return Task.CompletedTask;
+                }).ConfigureAwait(false);
 
                 if (activeGame.IsInIgnoredPath())
                 {

--- a/src/Data/EAApp/EAAppLibrary.cs
+++ b/src/Data/EAApp/EAAppLibrary.cs
@@ -176,9 +176,18 @@ internal class EAAppLibrary : IGameLibrary
                                     var cachedGame = GameManager.Instance.GetGame<EAAppGame>(contentId);
                                     var activeGame = cachedGame ?? new EAAppGame(contentId);
 
-                                    activeGame.Title = name;
-                                    activeGame.InstallPath = installPath;
-                                    activeGame.DisplayIconPath = programUninstallSubKey.GetValue("DisplayIcon")?.ToString()?.Trim('"') ?? string.Empty;
+                                    // These are UI-bound properties. Parallel.ForEachAsync above always schedules its
+                                    // work on the thread pool, never the UI thread, so these must be marshalled
+                                    // explicitly or WinUI throws RPC_E_WRONGTHREAD when a bound control is updated
+                                    // from a background thread.
+                                    await App.CurrentApp.RunOnUIThreadAsync(() =>
+                                    {
+                                        activeGame.Title = name;
+                                        activeGame.InstallPath = installPath;
+                                        activeGame.DisplayIconPath = programUninstallSubKey.GetValue("DisplayIcon")?.ToString()?.Trim('"') ?? string.Empty;
+
+                                        return Task.CompletedTask;
+                                    }).ConfigureAwait(false);
 
                                     if (activeGame.IsInIgnoredPath())
                                     {

--- a/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
+++ b/src/Data/EpicGamesStore/EpicGamesStoreLibrary.cs
@@ -144,9 +144,18 @@ internal class EpicGamesStoreLibrary : IGameLibrary
 
                 var cachedGame = GameManager.Instance.GetGame<EpicGamesStoreGame>(manifest.CatalogItemId);
                 var activeGame = cachedGame ?? new EpicGamesStoreGame(manifest.CatalogItemId);
-                activeGame.RemoteHeaderImage = remoteHeaderUrl;
-                activeGame.Title = manifest.DisplayName; // TODO: Will this be a problem if the game is already loaded
-                activeGame.InstallPath = PathHelpers.NormalizePath(manifest.InstallLocation);
+
+                // These are UI-bound properties. The File.ReadAllTextAsync().ConfigureAwait(false) above has already
+                // taken us off the UI thread, so these must be marshalled explicitly or WinUI throws RPC_E_WRONGTHREAD
+                // when a bound control is updated from a background thread.
+                await App.CurrentApp.RunOnUIThreadAsync(() =>
+                {
+                    activeGame.RemoteHeaderImage = remoteHeaderUrl;
+                    activeGame.Title = manifest.DisplayName;
+                    activeGame.InstallPath = PathHelpers.NormalizePath(manifest.InstallLocation);
+
+                    return Task.CompletedTask;
+                }).ConfigureAwait(false);
 
                 if (activeGame.IsInIgnoredPath())
                 {

--- a/src/Data/Game.cs
+++ b/src/Data/Game.cs
@@ -234,6 +234,11 @@ public abstract partial class Game : ObservableObject, IComparable<Game>, IEquat
         };
     }
 
+    // Bounds how many games can be scanned for DLLs/covers at once. Every game with no previously known
+    // DLLs is re-queued for processing on every launch, so without a limit a large library fires off
+    // hundreds of concurrent recursive directory scans and UI-thread updates at startup.
+    static readonly SemaphoreSlim processGameSemaphore = new SemaphoreSlim(4);
+
     /// <summary>
     /// Detects DLSS and updates cover image.
     /// </summary>
@@ -268,6 +273,8 @@ public abstract partial class Game : ObservableObject, IComparable<Game>, IEquat
 
         ThreadPool.QueueUserWorkItem(async (stateInfo) =>
         {
+            await processGameSemaphore.WaitAsync().ConfigureAwait(false);
+
             var newHasSwappableItems = false;
 
             try
@@ -564,6 +571,8 @@ public abstract partial class Game : ObservableObject, IComparable<Game>, IEquat
             }
             finally
             {
+                processGameSemaphore.Release();
+
                 // Now update all the data on the UI therad.
                 await App.CurrentApp.RunOnUIThreadAsync(async () =>
                 {

--- a/src/Data/Steam/SteamLibrary.cs
+++ b/src/Data/Steam/SteamLibrary.cs
@@ -220,15 +220,22 @@ internal partial class SteamLibrary : IGameLibrary
             var cachedGame = GameManager.Instance.GetGame<SteamGame>(game.PlatformId);
             var activeGame = cachedGame ?? game;
 
-            if (activeGame.IsHidden is null && _defaultHiddenGames.Contains(activeGame.PlatformId))
+            // These are UI-bound properties. Once the SaveToDatabaseAsync().ConfigureAwait(false) below has run for
+            // an earlier game in this loop we are no longer on the UI thread, so these must be marshalled explicitly
+            // or WinUI throws RPC_E_WRONGTHREAD when a bound control is updated from a background thread.
+            await App.CurrentApp.RunOnUIThreadAsync(() =>
             {
-                activeGame.IsHidden = true;
-            }
+                if (activeGame.IsHidden is null && _defaultHiddenGames.Contains(activeGame.PlatformId))
+                {
+                    activeGame.IsHidden = true;
+                }
 
+                activeGame.Title = game.Title;
+                activeGame.InstallPath = game.InstallPath;
+                activeGame.StateFlags = game.StateFlags;
 
-            activeGame.Title = game.Title;  // TODO: Will this be a problem if the game is already loaded
-            activeGame.InstallPath = game.InstallPath;
-            activeGame.StateFlags = game.StateFlags;
+                return Task.CompletedTask;
+            }).ConfigureAwait(false);
 
             if (activeGame.IsInIgnoredPath())
             {

--- a/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
+++ b/src/Data/UbisoftConnect/UbisoftConnectLibrary.cs
@@ -220,9 +220,18 @@ internal class UbisoftConnectLibrary : IGameLibrary
 
                             var cachedGame = GameManager.Instance.GetGame<UbisoftConnectGame>(configurationRecord.InstallId.ToString(CultureInfo.InvariantCulture));
                             var activeGame = cachedGame ?? new UbisoftConnectGame(configurationRecord.InstallId.ToString(CultureInfo.InvariantCulture));
-                            activeGame.Title = ubisoftConnectConfigurationItem.Root.Installer.GameIdentifier;  // TODO: Will this be a problem if the game is already loaded
-                            activeGame.InstallPath = PathHelpers.NormalizePath(installedTitle.InstallPath);
-                            activeGame.RemoteHeaderImage = remoteImage;
+
+                            // These are UI-bound properties. The File.ReadAllBytesAsync().ConfigureAwait(false) earlier
+                            // has already taken us off the UI thread, so these must be marshalled explicitly or WinUI
+                            // throws RPC_E_WRONGTHREAD when a bound control is updated from a background thread.
+                            await App.CurrentApp.RunOnUIThreadAsync(() =>
+                            {
+                                activeGame.Title = ubisoftConnectConfigurationItem.Root.Installer.GameIdentifier;
+                                activeGame.InstallPath = PathHelpers.NormalizePath(installedTitle.InstallPath);
+                                activeGame.RemoteHeaderImage = remoteImage;
+
+                                return Task.CompletedTask;
+                            }).ConfigureAwait(false);
 
                             if (activeGame.IsInIgnoredPath())
                             {

--- a/src/Pages/GameGridPageModel.cs
+++ b/src/Pages/GameGridPageModel.cs
@@ -79,13 +79,21 @@ public partial class GameGridPageModel : ObservableObject
         IsGameListLoading = true;
         IsDLSSLoading = true;
 
-        await GameManager.Instance.LoadGamesFromCacheAsync();
+        try
+        {
+            await GameManager.Instance.LoadGamesFromCacheAsync();
 
-        IsGameListLoading = false;
+            IsGameListLoading = false;
 
-        await GameManager.Instance.LoadGamesAsync(false);
-
-        IsDLSSLoading = false;
+            await GameManager.Instance.LoadGamesAsync(false);
+        }
+        finally
+        {
+            // Even if a game library throws, don't leave the UI stuck showing a loading spinner forever.
+            // GameGridPage.xaml.cs's SafeFireAndForget call already logs the exception.
+            IsGameListLoading = false;
+            IsDLSSLoading = false;
+        }
     }
 
     public void SearchForGameEvent(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
## Description of Changes

Fixes the scan that never finishes / spinner stuck forever bug described in #909.

Steam, Battle.net, Epic Games Store, Ubisoft Connect and EA App all set UI-bound `Game` properties (`Title`, `InstallPath`, `StateFlags`, etc.) after execution has already moved off the UI thread (via an earlier `ConfigureAwait(false)`, or for EA App inside a `Parallel.ForEachAsync` body, which never runs on the UI thread at all). When a bound control actually needed updating, WinUI threw `COMException (0x8001010E)` / `RPC_E_WRONGTHREAD`, which was never caught. That aborted the scan for every remaining game in that library and left `GameGridPageModel.InitialLoadAsync` unable to reach the code that clears the loading spinner, leaving it stuck indefinitely - matching the log signature in #909's thread exactly.

Three commits:

1. **Fix RPC_E_WRONGTHREAD crash in game library scanners** - marshal the UI-bound property writes back onto the UI thread with `App.CurrentApp.RunOnUIThreadAsync` before continuing, in the five library scanners that were actually vulnerable (verified by tracing which ones had a context-dropping `await` ahead of the property writes; GOG, Xbox and ManuallyAdded don't have this issue and are untouched).
2. **Ensure game grid loading spinner always clears on scan failure** - defence in depth: wrap `InitialLoadAsync`'s loads in `try/finally` so the spinner can't get permanently stuck again from some other future exception, while still letting `GameGridPage.xaml.cs`'s existing `SafeFireAndForget` logging see the exception.
3. **Limit concurrent game processing to avoid a startup I/O/UI flood** - every game with no previously known DLLs gets re-queued for a full recursive directory scan on every launch (pre-existing behaviour); previously this rarely ran to completion because of the crash above. Now that scans actually finish, an unthrottled library would fire off one concurrent scan (and UI-thread update) per not-yet-processed game with no cap at all. Capped concurrent `ProcessGame` executions with a `SemaphoreSlim` so this doesn't overwhelm disk I/O or the UI thread. The chosen limit (4) is still under discussion in review, see the PR comments.

#909 was reported against a 2-drive library (Ryzen 9 9900X, 12c/24t). @beeradmoore independently re-tested this fix against his own real ~60-game library spread across several SSDs (5950X, 16c/32t): the scan that previously never completed now finishes reliably, averaging 12.2s with this PR's `SemaphoreSlim(4)` versus 23.8s before it. See the PR review thread for the full concurrency-tuning discussion, including further local benchmarking, that followed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

#909

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014mYanCg6fAVVe6JGkAjTRw
