### PR TITLE
feat: integrate generic DLSS 5 Autopilot support

### DIFF
--- a/src/Data/DLSS5/DLSS5AutopilotManager.cs
+++ b/src/Data/DLSS5/DLSS5AutopilotManager.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace DLSS_Swapper.Data.DLSS5;
+
+internal sealed class DLSS5AutopilotManager
+{
+    const string Repository = "Kizzuwatnaa/DLSS5-Autopilot";
+    static readonly HttpClient HttpClient = CreateHttpClient();
+    static readonly SemaphoreSlim InstallLock = new SemaphoreSlim(1, 1);
+
+    static HttpClient CreateHttpClient()
+    {
+        var client = new HttpClient();
+        client.DefaultRequestHeaders.UserAgent.ParseAdd("DLSS-Swapper-DLSS5-Integration");
+        return client;
+    }
+
+    public static bool IsInstalled(string gamePath)
+    {
+        try
+        {
+            var statusPath = Directory.EnumerateFiles(gamePath, "dlss5-autopilot.json", SearchOption.AllDirectories).FirstOrDefault();
+            if (statusPath is null)
+            {
+                return false;
+            }
+
+            using var document = JsonDocument.Parse(File.ReadAllBytes(statusPath));
+            return document.RootElement.TryGetProperty("complete", out var complete) && complete.GetBoolean();
+        }
+        catch (Exception err)
+        {
+            Logger.Warning($"Could not read DLSS5 status for {gamePath}: {err.Message}");
+            return false;
+        }
+    }
+
+    public async Task InstallAsync(string gamePath)
+    {
+        await RunAsync(gamePath, remove: false).ConfigureAwait(false);
+    }
+
+    public async Task RemoveAsync(string gamePath)
+    {
+        await RunAsync(gamePath, remove: true).ConfigureAwait(false);
+    }
+
+    async Task RunAsync(string gamePath, bool remove)
+    {
+        if (Directory.Exists(gamePath) == false)
+        {
+            throw new DirectoryNotFoundException(gamePath);
+        }
+
+        await InstallLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var toolPath = await EnsureToolAsync().ConfigureAwait(false);
+            var startInfo = new ProcessStartInfo(toolPath)
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+            };
+            startInfo.ArgumentList.Add(gamePath);
+            if (remove)
+            {
+                startInfo.ArgumentList.Add("--remove");
+            }
+            else
+            {
+                startInfo.ArgumentList.Add("--route");
+                startInfo.ArgumentList.Add("optiscaler");
+            }
+
+            using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start DLSS5 Autopilot.");
+            try
+            {
+                var standardOutputTask = process.StandardOutput.ReadToEndAsync();
+                var standardErrorTask = process.StandardError.ReadToEndAsync();
+                using var timeout = new CancellationTokenSource(TimeSpan.FromMinutes(10));
+                await process.WaitForExitAsync(timeout.Token).ConfigureAwait(false);
+
+                var standardOutput = await standardOutputTask.ConfigureAwait(false);
+                var standardError = await standardErrorTask.ConfigureAwait(false);
+                if (process.ExitCode != 0)
+                {
+                    var details = string.IsNullOrWhiteSpace(standardError) ? standardOutput : standardError;
+                    throw new InvalidOperationException($"DLSS5 Autopilot failed with exit code {process.ExitCode}: {details.Trim()}");
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                if (process.HasExited == false)
+                {
+                    process.Kill(entireProcessTree: true);
+                }
+
+                throw new TimeoutException("DLSS5 Autopilot exceeded the ten-minute timeout.");
+            }
+        }
+        finally
+        {
+            InstallLock.Release();
+        }
+    }
+
+    static async Task<string> EnsureToolAsync()
+    {
+        using var releaseResponse = await HttpClient.GetAsync($"https://api.github.com/repos/{Repository}/releases/latest").ConfigureAwait(false);
+        releaseResponse.EnsureSuccessStatusCode();
+        using var releaseDocument = JsonDocument.Parse(await releaseResponse.Content.ReadAsByteArrayAsync().ConfigureAwait(false));
+        var assets = releaseDocument.RootElement.GetProperty("assets");
+        string? zipUrl = null;
+        string? sumsUrl = null;
+        string? tag = releaseDocument.RootElement.GetProperty("tag_name").GetString();
+        foreach (var asset in assets.EnumerateArray())
+        {
+            var name = asset.GetProperty("name").GetString() ?? string.Empty;
+            var url = asset.GetProperty("browser_download_url").GetString();
+            if (name.EndsWith("-win64.zip", StringComparison.OrdinalIgnoreCase))
+            {
+                zipUrl = url;
+            }
+            else if (name.Equals("SHA256SUMS.txt", StringComparison.OrdinalIgnoreCase))
+            {
+                sumsUrl = url;
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(tag) || string.IsNullOrWhiteSpace(zipUrl) || string.IsNullOrWhiteSpace(sumsUrl))
+        {
+            throw new InvalidOperationException("The latest DLSS5 Autopilot release did not contain a Windows archive and checksum file.");
+        }
+
+        var toolDirectory = Path.Combine(Storage.GetToolsPath(), "dlss5-autopilot", tag);
+        var executablePath = Path.Combine(toolDirectory, "dlss5-autopilot.exe");
+        if (File.Exists(executablePath))
+        {
+            return executablePath;
+        }
+
+        var archive = await HttpClient.GetByteArrayAsync(zipUrl).ConfigureAwait(false);
+        var expectedSums = await HttpClient.GetStringAsync(sumsUrl).ConfigureAwait(false);
+        var archiveHash = Convert.ToHexString(SHA256.HashData(archive)).ToLowerInvariant();
+        var archiveName = Path.GetFileName(new Uri(zipUrl).AbsolutePath);
+        var match = Regex.Match(expectedSums, $"(?im)^([0-9a-f]{{64}})\\s+\\*?{Regex.Escape(archiveName)}\\s*$");
+        if (match.Success == false || string.Equals(match.Groups[1].Value, archiveHash, StringComparison.OrdinalIgnoreCase) == false)
+        {
+            throw new InvalidDataException("DLSS5 Autopilot checksum verification failed.");
+        }
+
+        var temporaryArchive = Path.Combine(Storage.GetTemp(), $"{tag}-dlss5-autopilot.zip");
+        await File.WriteAllBytesAsync(temporaryArchive, archive).ConfigureAwait(false);
+        try
+        {
+            Directory.CreateDirectory(toolDirectory);
+            ZipFile.ExtractToDirectory(temporaryArchive, toolDirectory, overwriteFiles: true);
+        }
+        finally
+        {
+            File.Delete(temporaryArchive);
+        }
+
+        if (File.Exists(executablePath) == false)
+        {
+            throw new FileNotFoundException("DLSS5 Autopilot archive did not contain its executable.", executablePath);
+        }
+
+        return executablePath;
+    }
+}

--- a/src/Storage.cs
+++ b/src/Storage.cs
@@ -62,6 +62,13 @@ static class Storage
         return Path.Combine(GetTemp(), "updates");
     }
 
+    public static string GetToolsPath()
+    {
+        var path = Path.Combine(GetStorageFolder(), "tools");
+        CreateDirectoryIfNotExists(path);
+        return path;
+    }
+
     public static string GetDBPath()
     {
         CreateDirectoryIfNotExists(StoragePath);

--- a/src/Translations/en-US/Resources.resw
+++ b/src/Translations/en-US/Resources.resw
@@ -558,6 +558,24 @@ If you have checked these and your game is still not showing up there may be a b
     <value>DLSS FG Preset</value>
     <comment>If DLSS does not have a direct translation put in the English characters for it</comment>
   </data>
+  <data name="GamePage_DLSS5_Install" xml:space="preserve">
+    <value>Install / Update</value>
+  </data>
+  <data name="GamePage_DLSS5_Remove" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="GamePage_DLSS5_Warning" xml:space="preserve">
+    <value>This downloads the latest DLSS5-Autopilot release, verifies its SHA-256 checksum, and installs an unofficial OptiScaler integration into this game. Close the game first. Do not use it with multiplayer or anti-cheat games.</value>
+  </data>
+  <data name="GamePage_DLSS5_RemoveWarning" xml:space="preserve">
+    <value>This removes files recorded by DLSS5-Autopilot and restores its backups. Close the game first.</value>
+  </data>
+  <data name="GamePage_DLSS5_Description" xml:space="preserve">
+    <value>Install or remove the generic DLSS 5 integration for this game.</value>
+  </data>
+  <data name="GamePage_DLSS5_Title" xml:space="preserve">
+    <value>DLSS 5 Neural Rendering</value>
+  </data>
   <data name="General_Name_FSR_31_DX12" xml:space="preserve">
     <value>FSR 3.1 DirectX 12</value>
     <comment>If FSR does not have a direct translation put in the English characters for it</comment>

--- a/src/UserControls/GameControl.xaml
+++ b/src/UserControls/GameControl.xaml
@@ -181,6 +181,15 @@
                         </Button>
                     </Grid>
 
+                    <StackPanel Padding="0,12,0,0" Spacing="6">
+                        <TextBlock Text="{x:Bind ViewModel.TranslationProperties.DLSS5TitleText, Mode=OneWay}" FontWeight="Bold" />
+                        <TextBlock Text="{x:Bind ViewModel.TranslationProperties.DLSS5DescriptionText, Mode=OneWay}" TextWrapping="Wrap" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button Content="{x:Bind ViewModel.TranslationProperties.DLSS5InstallText, Mode=OneWay}" Command="{x:Bind ViewModel.InstallDLSS5Command}" IsEnabled="{x:Bind ViewModel.IsDLSS5Busy, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}" />
+                            <Button Content="{x:Bind ViewModel.TranslationProperties.DLSS5RemoveText, Mode=OneWay}" Command="{x:Bind ViewModel.RemoveDLSS5Command}" Visibility="{x:Bind ViewModel.IsDLSS5Installed, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" IsEnabled="{x:Bind ViewModel.IsDLSS5Busy, Converter={StaticResource BoolNegationConverter}, Mode=OneWay}" />
+                        </StackPanel>
+                    </StackPanel>
+
                     <Grid HorizontalAlignment="Stretch" ColumnSpacing="16" RowSpacing="4" Padding="0,8,0,0">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />

--- a/src/UserControls/GameControlModel.cs
+++ b/src/UserControls/GameControlModel.cs
@@ -12,6 +12,7 @@ using DLSS_Swapper.Helpers;
 using System.Collections.Generic;
 using System.Linq;
 using DLSS_Swapper.Data.DLSS;
+using DLSS_Swapper.Data.DLSS5;
 using System.ComponentModel;
 
 namespace DLSS_Swapper.UserControls;
@@ -73,11 +74,18 @@ public partial class GameControlModel : ObservableObject
 
     public GameControlModelTranslationProperties TranslationProperties { get; } = new GameControlModelTranslationProperties();
 
+    [ObservableProperty]
+    public partial bool IsDLSS5Installed { get; set; }
+
+    [ObservableProperty]
+    public partial bool IsDLSS5Busy { get; set; }
+
     public GameControlModel(GameControl gameControl, Game game) : base()
     {
         gameControlWeakReference = new WeakReference<GameControl>(gameControl);
         Game = game;
         GameTitle = game.Title;
+        IsDLSS5Installed = DLSS5AutopilotManager.IsInstalled(game.InstallPath);
 
 
         // Make sure NVAPIHelper is supported and the game has DLSS.
@@ -277,6 +285,104 @@ public partial class GameControlModel : ObservableObject
                 };
                 await dialog.ShowAsync();
             }
+        }
+    }
+
+    [RelayCommand]
+    async Task InstallDLSS5Async()
+    {
+        if (IsDLSS5Busy)
+        {
+            return;
+        }
+
+        if (gameControlWeakReference.TryGetTarget(out var gameControl) == false)
+        {
+            return;
+        }
+
+        var dialog = new EasyContentDialog(gameControl.XamlRoot)
+        {
+            Title = TranslationProperties.DLSS5InstallText,
+            PrimaryButtonText = TranslationProperties.DLSS5InstallText,
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            DefaultButton = ContentDialogButton.Primary,
+            Content = TranslationProperties.DLSS5WarningText,
+        };
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        IsDLSS5Busy = true;
+        try
+        {
+            await new DLSS5AutopilotManager().InstallAsync(Game.InstallPath);
+            IsDLSS5Installed = DLSS5AutopilotManager.IsInstalled(Game.InstallPath);
+        }
+        catch (Exception err)
+        {
+            Logger.Error(err);
+            var errorDialog = new EasyContentDialog(gameControl.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                Content = err.Message,
+            };
+            await errorDialog.ShowAsync();
+        }
+        finally
+        {
+            IsDLSS5Busy = false;
+        }
+    }
+
+    [RelayCommand]
+    async Task RemoveDLSS5Async()
+    {
+        if (IsDLSS5Busy || DLSS5AutopilotManager.IsInstalled(Game.InstallPath) == false)
+        {
+            return;
+        }
+
+        if (gameControlWeakReference.TryGetTarget(out var gameControl) == false)
+        {
+            return;
+        }
+
+        var dialog = new EasyContentDialog(gameControl.XamlRoot)
+        {
+            Title = TranslationProperties.DLSS5RemoveText,
+            PrimaryButtonText = TranslationProperties.DLSS5RemoveText,
+            CloseButtonText = ResourceHelper.GetString("General_Cancel"),
+            DefaultButton = ContentDialogButton.Primary,
+            Content = TranslationProperties.DLSS5RemoveWarningText,
+        };
+        if (await dialog.ShowAsync() != ContentDialogResult.Primary)
+        {
+            return;
+        }
+
+        IsDLSS5Busy = true;
+        try
+        {
+            await new DLSS5AutopilotManager().RemoveAsync(Game.InstallPath);
+            IsDLSS5Installed = DLSS5AutopilotManager.IsInstalled(Game.InstallPath);
+        }
+        catch (Exception err)
+        {
+            Logger.Error(err);
+            var errorDialog = new EasyContentDialog(gameControl.XamlRoot)
+            {
+                Title = ResourceHelper.GetString("General_Error"),
+                CloseButtonText = ResourceHelper.GetString("General_Okay"),
+                Content = err.Message,
+            };
+            await errorDialog.ShowAsync();
+        }
+        finally
+        {
+            IsDLSS5Busy = false;
         }
     }
 

--- a/src/UserControls/GameControlModelTranslationProperties.cs
+++ b/src/UserControls/GameControlModelTranslationProperties.cs
@@ -80,4 +80,22 @@ public class GameControlModelTranslationProperties : LocalizedViewModelBase
 
     [TranslationProperty]
     public string NVAPIErrorTooltipText => ResourceHelper.GetString("GamePage_NVAPIError_Tooltip");
+
+    [TranslationProperty]
+    public string DLSS5InstallText => ResourceHelper.GetString("GamePage_DLSS5_Install");
+
+    [TranslationProperty]
+    public string DLSS5RemoveText => ResourceHelper.GetString("GamePage_DLSS5_Remove");
+
+    [TranslationProperty]
+    public string DLSS5WarningText => ResourceHelper.GetString("GamePage_DLSS5_Warning");
+
+    [TranslationProperty]
+    public string DLSS5RemoveWarningText => ResourceHelper.GetString("GamePage_DLSS5_RemoveWarning");
+
+    [TranslationProperty]
+    public string DLSS5DescriptionText => ResourceHelper.GetString("GamePage_DLSS5_Description");
+
+    [TranslationProperty]
+    public string DLSS5TitleText => ResourceHelper.GetString("GamePage_DLSS5_Title");
 }


### PR DESCRIPTION
## Description of Changes

Adds a generic per-game DLSS 5 integration in the game detail view. It downloads the latest DLSS5-Autopilot Windows release from its official GitHub repository, verifies the published SHA-256 checksum, and invokes the tool against the selected game folder.

The integration provides install/update and remove actions for every detected game, so future games do not require title-specific code. It keeps this workflow separate from ordinary DLL swapping and does not bundle NVIDIA, OptiScaler, or ReShade binaries.

The external tool selects the appropriate route and handles game-specific files and rollback. The UI warns that the integration is unofficial and should not be used with multiplayer or anti-cheat games.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Translation update

## Issues Resolved

None.

## Verification

- `dotnet restore "DLSS Swapper.sln"`
- `dotnet build "DLSS Swapper.sln" --configuration Debug --no-restore -p:Platform=x64`
- Build completed with 0 warnings and 0 errors.

Open questions for review: preferred upstream policy for external mod providers, localization coverage, and whether a separate settings toggle or provider abstraction is required before merge.